### PR TITLE
feat: add getBudgetMonth and setBudgetAmount operations

### DIFF
--- a/nodes/ActualBudget/ActualBudget.node.ts
+++ b/nodes/ActualBudget/ActualBudget.node.ts
@@ -12,6 +12,8 @@ import {
 	init,
 	downloadBudget,
 	importTransactions,
+	getBudgetMonth,
+	setBudgetAmount,
 	shutdown,
 } from '@actual-app/api';
 
@@ -68,9 +70,19 @@ export class ActualBudget implements INodeType {
 				type: 'options',
 				options: [
 					{
+						name: 'Get Budget Month',
+						value: 'getBudgetMonth',
+						action: 'Get budget data for a specific month',
+					},
+					{
 						name: 'Import Transactions',
 						value: 'importTransactions',
 						action: 'Import a list of transactions into your budget',
+					},
+					{
+						name: 'Set Budget Amount',
+						value: 'setBudgetAmount',
+						action: 'Set the budget amount for a category in a specific month',
 					},
 				],
 				default: 'importTransactions',
@@ -97,6 +109,45 @@ export class ActualBudget implements INodeType {
 				default: '[]',
 				required: true,
 			},
+			{
+				displayName: 'Month',
+				name: 'month',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'Month in YYYY-MM format',
+				displayOptions: {
+					show: {
+						operation: ['getBudgetMonth', 'setBudgetAmount'],
+					},
+				},
+			},
+			{
+				displayName: 'Category ID',
+				name: 'categoryId',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'The ID of the budget category',
+				displayOptions: {
+					show: {
+						operation: ['setBudgetAmount'],
+					},
+				},
+			},
+			{
+				displayName: 'Amount',
+				name: 'amount',
+				type: 'number',
+				default: 0,
+				required: true,
+				description: 'Budget amount in millicents (e.g. 100000 = $100.00)',
+				displayOptions: {
+					show: {
+						operation: ['setBudgetAmount'],
+					},
+				},
+			},
 		],
 		usableAsTool: undefined,
 	};
@@ -117,8 +168,18 @@ export class ActualBudget implements INodeType {
 			try {
 				let elementData;
 				switch (action) {
+					case 'getBudgetMonth':
+						if (itemIndex === 0) {
+							elementData = await handleGetBudgetMonth(this, itemIndex);
+							returnData.push(elementData);
+						}
+						break;
 					case 'importTransactions':
 						elementData = await handleBudgetImport(this, itemIndex);
+						returnData.push(elementData);
+						break;
+					case 'setBudgetAmount':
+						elementData = await handleSetBudgetAmount(this, itemIndex);
 						returnData.push(elementData);
 						break;
 				}
@@ -139,6 +200,25 @@ export class ActualBudget implements INodeType {
 		await shutdown();
 		return [this.helpers.returnJsonArray(returnData)];
 	}
+}
+
+async function handleGetBudgetMonth(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const month = context.getNodeParameter('month', itemIndex) as string;
+	return (await getBudgetMonth(month)) as unknown as IDataObject;
+}
+
+async function handleSetBudgetAmount(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const month = context.getNodeParameter('month', itemIndex) as string;
+	const categoryId = context.getNodeParameter('categoryId', itemIndex) as string;
+	const amount = context.getNodeParameter('amount', itemIndex) as number;
+	await setBudgetAmount(month, categoryId, amount);
+	return { success: true, month, categoryId, amount };
 }
 
 async function initializeActualBudget(auth: Credentials): Promise<void> {

--- a/nodes/ActualBudget/ActualBudget.node.ts
+++ b/nodes/ActualBudget/ActualBudget.node.ts
@@ -169,10 +169,8 @@ export class ActualBudget implements INodeType {
 				let elementData;
 				switch (action) {
 					case 'getBudgetMonth':
-						if (itemIndex === 0) {
-							elementData = await handleGetBudgetMonth(this, itemIndex);
-							returnData.push(elementData);
-						}
+						elementData = await handleGetBudgetMonth(this, itemIndex);
+						returnData.push(elementData);
 						break;
 					case 'importTransactions':
 						elementData = await handleBudgetImport(this, itemIndex);

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -91,8 +91,10 @@ SETUP_OUTPUT=$(ACTUAL_TEST_URL="$ACTUAL_TEST_URL" ACTUAL_TEST_PASS="$ACTUAL_TEST
 
 BUDGET_ID=$(echo "$SETUP_OUTPUT" | python3 -c "import json,sys; print(json.load(sys.stdin)['budgetId'])")
 ACCOUNT_ID=$(echo "$SETUP_OUTPUT" | python3 -c "import json,sys; print(json.load(sys.stdin)['accountId'])")
+CATEGORY_ID=$(echo "$SETUP_OUTPUT" | python3 -c "import json,sys; print(json.load(sys.stdin)['categoryId'])")
 echo "✓ Budget ID: $BUDGET_ID"
 echo "✓ Account ID: $ACCOUNT_ID"
+echo "✓ Category ID: $CATEGORY_ID"
 
 # Generate workflow JSON with the real budget + account IDs
 echo "Generating integration workflow..."
@@ -201,6 +203,7 @@ export ACTUAL_TEST_URL
 export ACTUAL_TEST_PASS
 export ACTUAL_TEST_BUDGET_ID="$BUDGET_ID"
 export ACTUAL_TEST_ACCOUNT_ID="$ACCOUNT_ID"
+export ACTUAL_TEST_CATEGORY_ID="$CATEGORY_ID"
 
 set +e
 npm run test:run

--- a/scripts/setup-actual-budget.mjs
+++ b/scripts/setup-actual-budget.mjs
@@ -42,15 +42,19 @@ if (accounts.length === 0) {
 
 const accountId = accounts[0].id;
 
-// Find or create a test expense category
+// Find or create a dedicated E2E test expense category (never reuse an arbitrary existing one)
 const allCategories = await api.getCategories();
-const expenseCategories = allCategories.filter((c) => c.group_id && !c.is_income);
+const existingCategory = allCategories.find((c) => c.name === "E2E Test Expenses" && c.group_id && !c.is_income);
 let categoryId;
-if (expenseCategories.length === 0) {
-  const groupId = await api.createCategoryGroup({ name: "E2E Test", is_income: false, hidden: false });
-  categoryId = await api.createCategory({ name: "E2E Test Expenses", group_id: groupId, is_income: false, hidden: false });
+if (existingCategory) {
+  categoryId = existingCategory.id;
 } else {
-  categoryId = expenseCategories[0].id;
+  const allGroups = await api.getCategoryGroups();
+  const existingGroup = allGroups.find((g) => g.name === "E2E Test");
+  const groupId = existingGroup
+    ? existingGroup.id
+    : await api.createCategoryGroup({ name: "E2E Test", is_income: false, hidden: false });
+  categoryId = await api.createCategory({ name: "E2E Test Expenses", group_id: groupId, is_income: false, hidden: false });
 }
 
 await api.shutdown();

--- a/scripts/setup-actual-budget.mjs
+++ b/scripts/setup-actual-budget.mjs
@@ -42,7 +42,18 @@ if (accounts.length === 0) {
 
 const accountId = accounts[0].id;
 
+// Find or create a test expense category
+const allCategories = await api.getCategories();
+const expenseCategories = allCategories.filter((c) => c.group_id && !c.is_income);
+let categoryId;
+if (expenseCategories.length === 0) {
+  const groupId = await api.createCategoryGroup({ name: "E2E Test", is_income: false, hidden: false });
+  categoryId = await api.createCategory({ name: "E2E Test Expenses", group_id: groupId, is_income: false, hidden: false });
+} else {
+  categoryId = expenseCategories[0].id;
+}
+
 await api.shutdown();
 
 // Write JSON on its own line so callers can reliably extract it with `tail -1`
-process.stdout.write(JSON.stringify({ budgetId, accountId }) + "\n");
+process.stdout.write(JSON.stringify({ budgetId, accountId, categoryId }) + "\n");

--- a/scripts/setup-actual-budget.mjs
+++ b/scripts/setup-actual-budget.mjs
@@ -1,6 +1,6 @@
 /**
- * Creates (or reuses) an E2E test budget and account on the Actual Budget server.
- * Outputs {"budgetId":"...","accountId":"..."} to stdout.
+ * Creates (or reuses) an E2E test budget, account, and expense category on the Actual Budget server.
+ * Outputs {"budgetId":"...","accountId":"...","categoryId":"..."} to stdout.
  */
 import * as api from "@actual-app/api";
 import { mkdtempSync } from "fs";

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -8,6 +8,20 @@ vi.mock("@actual-app/api", () => ({
   importTransactions: vi
     .fn()
     .mockResolvedValue({ added: ["tx-001"], updated: [], updatedPreview: [], errors: [] }),
+  getBudgetMonth: vi.fn().mockResolvedValue({
+    month: "2024-01",
+    incomeAvailable: 500000,
+    lastMonthOverspent: 0,
+    forNextMonth: 0,
+    totalBudgeted: 300000,
+    toBudget: 200000,
+    fromLastMonth: 0,
+    totalIncome: 500000,
+    totalSpent: -300000,
+    totalBalance: 200000,
+    categoryGroups: [],
+  }),
+  setBudgetAmount: vi.fn().mockResolvedValue(undefined),
   shutdown: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -183,5 +197,168 @@ describe("ActualBudget", () => {
     const result = await node.execute.call(executeFunctions);
 
     expect(result[0][0].json).toEqual(importResult);
+  });
+
+  describe("getBudgetMonth operation", () => {
+    it("should call getBudgetMonth with the correct month parameter", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getBudgetMonth";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.getBudgetMonth).toHaveBeenCalledWith("2024-03");
+    });
+
+    it("should return getBudgetMonth result in output", async () => {
+      const budgetData = {
+        month: "2024-03",
+        toBudget: 150000,
+        totalIncome: 600000,
+        totalSpent: -450000,
+        totalBalance: 150000,
+        incomeAvailable: 600000,
+        lastMonthOverspent: 0,
+        forNextMonth: 0,
+        totalBudgeted: 450000,
+        fromLastMonth: 0,
+        categoryGroups: [{ id: "grp-1", name: "Food" }],
+      };
+      vi.mocked(actualApi.getBudgetMonth).mockResolvedValueOnce(budgetData as unknown);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getBudgetMonth";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(result[0][0].json).toEqual(budgetData);
+    });
+
+    it("should output exactly one item even with multiple input items", async () => {
+      executeFunctions.getInputData.mockReturnValue([{ json: {} }, { json: {} }, { json: {} }]);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getBudgetMonth";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getBudgetMonth).toHaveBeenCalledTimes(1);
+      expect(result[0]).toHaveLength(1);
+    });
+
+    it("should call shutdown before re-throwing on getBudgetMonth error", async () => {
+      vi.mocked(actualApi.getBudgetMonth).mockRejectedValueOnce(new Error("month not found"));
+      executeFunctions.continueOnFail.mockReturnValue(false);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getBudgetMonth";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow("month not found");
+
+      expect(actualApi.shutdown).toHaveBeenCalled();
+    });
+  });
+
+  describe("setBudgetAmount operation", () => {
+    it("should call setBudgetAmount with correct month, categoryId, and amount", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "setBudgetAmount";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        if (name === "categoryId") return "cat-abc";
+        if (name === "amount") return 100000;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.setBudgetAmount).toHaveBeenCalledWith("2024-03", "cat-abc", 100000);
+    });
+
+    it("should return echo object with written parameters", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "setBudgetAmount";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        if (name === "categoryId") return "cat-abc";
+        if (name === "amount") return 100000;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(result[0][0].json).toEqual({ success: true, month: "2024-03", categoryId: "cat-abc", amount: 100000 });
+    });
+
+    it("should call setBudgetAmount once per input item", async () => {
+      const items = [
+        { month: "2024-03", categoryId: "cat-1", amount: 50000 },
+        { month: "2024-03", categoryId: "cat-2", amount: 75000 },
+        { month: "2024-03", categoryId: "cat-3", amount: 25000 },
+      ];
+      executeFunctions.getInputData.mockReturnValue(items.map(() => ({ json: {} })));
+      executeFunctions.getNodeParameter.mockImplementation((name: string, itemIndex: number) => {
+        if (name === "operation") return "setBudgetAmount";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return items[itemIndex].month;
+        if (name === "categoryId") return items[itemIndex].categoryId;
+        if (name === "amount") return items[itemIndex].amount;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.setBudgetAmount).toHaveBeenCalledTimes(3);
+      expect(actualApi.setBudgetAmount).toHaveBeenNthCalledWith(1, "2024-03", "cat-1", 50000);
+      expect(actualApi.setBudgetAmount).toHaveBeenNthCalledWith(2, "2024-03", "cat-2", 75000);
+      expect(actualApi.setBudgetAmount).toHaveBeenNthCalledWith(3, "2024-03", "cat-3", 25000);
+    });
+
+    it("should call shutdown before re-throwing on setBudgetAmount error", async () => {
+      vi.mocked(actualApi.setBudgetAmount).mockRejectedValueOnce(new Error("write failed"));
+      executeFunctions.continueOnFail.mockReturnValue(false);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "setBudgetAmount";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        if (name === "categoryId") return "cat-abc";
+        if (name === "amount") return 100000;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow("write failed");
+
+      expect(actualApi.shutdown).toHaveBeenCalled();
+    });
+
+    it("should include error in output when continueOnFail=true", async () => {
+      vi.mocked(actualApi.setBudgetAmount).mockRejectedValueOnce(new Error("write failed"));
+      executeFunctions.continueOnFail.mockReturnValue(true);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "setBudgetAmount";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        if (name === "categoryId") return "cat-abc";
+        if (name === "amount") return 100000;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(result).toBeDefined();
+      expect(actualApi.shutdown).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -240,7 +240,7 @@ describe("ActualBudget", () => {
       expect(result[0][0].json).toEqual(budgetData);
     });
 
-    it("should output exactly one item even with multiple input items", async () => {
+    it("should call getBudgetMonth once per input item", async () => {
       executeFunctions.getInputData.mockReturnValue([{ json: {} }, { json: {} }, { json: {} }]);
       executeFunctions.getNodeParameter.mockImplementation((name: string) => {
         if (name === "operation") return "getBudgetMonth";
@@ -251,8 +251,8 @@ describe("ActualBudget", () => {
 
       const result = await node.execute.call(executeFunctions);
 
-      expect(actualApi.getBudgetMonth).toHaveBeenCalledTimes(1);
-      expect(result[0]).toHaveLength(1);
+      expect(actualApi.getBudgetMonth).toHaveBeenCalledTimes(3);
+      expect(result[0]).toHaveLength(3);
     });
 
     it("should call shutdown before re-throwing on getBudgetMonth error", async () => {

--- a/tests/ActualBudgetIntegration.spec.ts
+++ b/tests/ActualBudgetIntegration.spec.ts
@@ -13,6 +13,8 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
   const password = process.env.ACTUAL_TEST_PASS || "test-password";
   const budgetId = process.env.ACTUAL_TEST_BUDGET_ID!;
   const accountId = process.env.ACTUAL_TEST_ACCOUNT_ID!;
+  const categoryId = process.env.ACTUAL_TEST_CATEGORY_ID!;
+  const testMonth = process.env.ACTUAL_TEST_MONTH || new Date().toISOString().slice(0, 7);
 
   const dataDir = mkdtempSync(join(tmpdir(), "actual-integration-"));
 
@@ -66,4 +68,74 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
     expect(testTxn).toBeDefined();
     expect(testTxn!.amount).toBe(-2500);
   }, 15000);
+
+  it("should get budget month data via the node", async () => {
+    const node = new ActualBudget();
+    const executeFunctions = {
+      getInputData: () => [{ json: {} }],
+      getNodeParameter: (name: string) => {
+        if (name === "operation") return "getBudgetMonth";
+        if (name === "budgetId") return budgetId;
+        if (name === "month") return testMonth;
+        return undefined;
+      },
+      getCredentials: async () => ({ url: serverURL, password }),
+      continueOnFail: () => false,
+      helpers: {
+        returnJsonArray: (data: unknown) =>
+          Array.isArray(data)
+            ? data.map((d) => ({ json: d as IDataObject }))
+            : [{ json: data as IDataObject }],
+        constructExecutionMetaData: (data: unknown) => data,
+      },
+    } as unknown as IExecuteFunctions;
+
+    const result = await node.execute.call(executeFunctions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(1);
+
+    const output = result[0][0].json as Record<string, unknown>;
+    expect(output.month).toBe(testMonth);
+    expect(typeof output.toBudget).toBe("number");
+    expect(Array.isArray(output.categoryGroups)).toBe(true);
+  }, 15000);
+
+  it("should set budget amount via the node and reflect it in the budget", async () => {
+    const node = new ActualBudget();
+    const executeFunctions = {
+      getInputData: () => [{ json: {} }],
+      getNodeParameter: (name: string) => {
+        if (name === "operation") return "setBudgetAmount";
+        if (name === "budgetId") return budgetId;
+        if (name === "month") return testMonth;
+        if (name === "categoryId") return categoryId;
+        if (name === "amount") return 50000;
+        return undefined;
+      },
+      getCredentials: async () => ({ url: serverURL, password }),
+      continueOnFail: () => false,
+      helpers: {
+        returnJsonArray: (data: unknown) =>
+          Array.isArray(data)
+            ? data.map((d) => ({ json: d as IDataObject }))
+            : [{ json: data as IDataObject }],
+        constructExecutionMetaData: (data: unknown) => data,
+      },
+    } as unknown as IExecuteFunctions;
+
+    const result = await node.execute.call(executeFunctions);
+
+    expect(result[0][0].json).toMatchObject({ success: true, amount: 50000 });
+
+    // Re-init to verify the write persisted
+    await api.init({ serverURL, password, dataDir });
+    await api.downloadBudget(budgetId);
+    const budgetMonth = await api.getBudgetMonth(testMonth);
+    const category = budgetMonth.categoryGroups
+      .flatMap((g) => (g as Record<string, unknown> & { categories?: Record<string, unknown>[] }).categories ?? [])
+      .find((c) => (c as Record<string, unknown>).id === categoryId);
+    expect(category).toBeDefined();
+    expect((category as Record<string, unknown>).budgeted).toBe(50000);
+  }, 30000);
 });

--- a/tests/ActualBudgetIntegration.spec.ts
+++ b/tests/ActualBudgetIntegration.spec.ts
@@ -14,7 +14,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
   const budgetId = process.env.ACTUAL_TEST_BUDGET_ID!;
   const accountId = process.env.ACTUAL_TEST_ACCOUNT_ID!;
   const categoryId = process.env.ACTUAL_TEST_CATEGORY_ID!;
-  const testMonth = process.env.ACTUAL_TEST_MONTH || new Date().toISOString().slice(0, 7);
+  const testMonth = process.env.ACTUAL_TEST_MONTH ?? "2024-01";
 
   const dataDir = mkdtempSync(join(tmpdir(), "actual-integration-"));
 


### PR DESCRIPTION
Enables reading monthly budget data and programmatically setting category budget amounts — the two highest-value additions for budget automation workflows in n8n.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Get Budget Month" operation to fetch a month’s budget and category data.
  * "Set Budget Amount" operation to update a category’s budgeted amount for a month.

* **Tests**
  * Added unit and integration tests covering both operations, argument wiring, success/error flows, and continue-on-fail behavior.

* **Chores**
  * Test setup now ensures an E2E expense category and exposes its ID to the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->