### PR TITLE
feat: add getTransactions operation

### DIFF
--- a/nodes/ActualBudget/ActualBudget.node.ts
+++ b/nodes/ActualBudget/ActualBudget.node.ts
@@ -12,6 +12,7 @@ import {
 	init,
 	downloadBudget,
 	importTransactions,
+	getTransactions,
 	getBudgetMonth,
 	setBudgetAmount,
 	shutdown,
@@ -75,6 +76,11 @@ export class ActualBudget implements INodeType {
 						action: 'Get budget data for a specific month',
 					},
 					{
+						name: 'Get Transactions',
+						value: 'getTransactions',
+						action: 'Get transactions from an account within a date range',
+					},
+					{
 						name: 'Import Transactions',
 						value: 'importTransactions',
 						action: 'Import a list of transactions into your budget',
@@ -97,10 +103,36 @@ export class ActualBudget implements INodeType {
 				default: '',
 				displayOptions: {
 					show: {
-						operation: ['importTransactions'],
+						operation: ['importTransactions', 'getTransactions'],
 					},
 				},
 				required: true,
+			},
+			{
+				displayName: 'Start Date',
+				name: 'startDate',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'Start date in YYYY-MM-DD format (inclusive)',
+				displayOptions: {
+					show: {
+						operation: ['getTransactions'],
+					},
+				},
+			},
+			{
+				displayName: 'End Date',
+				name: 'endDate',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'End date in YYYY-MM-DD format (inclusive)',
+				displayOptions: {
+					show: {
+						operation: ['getTransactions'],
+					},
+				},
 			},
 			{
 				displayName: 'Transactions',
@@ -172,6 +204,9 @@ export class ActualBudget implements INodeType {
 						elementData = await handleGetBudgetMonth(this, itemIndex);
 						returnData.push(elementData);
 						break;
+					case 'getTransactions':
+						returnData.push(...(await handleGetTransactions(this, itemIndex)));
+						break;
 					case 'importTransactions':
 						elementData = await handleBudgetImport(this, itemIndex);
 						returnData.push(elementData);
@@ -198,6 +233,16 @@ export class ActualBudget implements INodeType {
 		await shutdown();
 		return [this.helpers.returnJsonArray(returnData)];
 	}
+}
+
+async function handleGetTransactions(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject[]> {
+	const accountId = context.getNodeParameter('accountId', itemIndex) as string;
+	const startDate = context.getNodeParameter('startDate', itemIndex) as string;
+	const endDate = context.getNodeParameter('endDate', itemIndex) as string;
+	return (await getTransactions(accountId, startDate, endDate)) as unknown as IDataObject[];
 }
 
 async function handleGetBudgetMonth(

--- a/nodes/ActualBudget/ActualBudget.node.ts
+++ b/nodes/ActualBudget/ActualBudget.node.ts
@@ -140,6 +140,11 @@ export class ActualBudget implements INodeType {
 				type: 'json',
 				default: '[]',
 				required: true,
+				displayOptions: {
+					show: {
+						operation: ['importTransactions'],
+					},
+				},
 			},
 			{
 				displayName: 'Month',
@@ -242,6 +247,16 @@ async function handleGetTransactions(
 	const accountId = context.getNodeParameter('accountId', itemIndex) as string;
 	const startDate = context.getNodeParameter('startDate', itemIndex) as string;
 	const endDate = context.getNodeParameter('endDate', itemIndex) as string;
+	const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+	if (!datePattern.test(startDate)) {
+		throw new NodeOperationError(context.getNode(), `"startDate" must be in YYYY-MM-DD format, got "${startDate}"`);
+	}
+	if (!datePattern.test(endDate)) {
+		throw new NodeOperationError(context.getNode(), `"endDate" must be in YYYY-MM-DD format, got "${endDate}"`);
+	}
+	if (startDate > endDate) {
+		throw new NodeOperationError(context.getNode(), `"startDate" (${startDate}) must be on or before "endDate" (${endDate})`);
+	}
 	return (await getTransactions(accountId, startDate, endDate)) as unknown as IDataObject[];
 }
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -45,6 +45,7 @@ describe("ActualBudget", () => {
         .fn()
         .mockResolvedValue({ url: "http://localhost:5006", password: "test-password" }),
       continueOnFail: vi.fn().mockReturnValue(false),
+      getNode: vi.fn().mockReturnValue({ name: "ActualBudget" }),
       helpers: {
         returnJsonArray: vi.fn((data: unknown) =>
           Array.isArray(data)
@@ -296,6 +297,45 @@ describe("ActualBudget", () => {
       await expect(node.execute.call(executeFunctions)).rejects.toThrow("account not found");
 
       expect(actualApi.shutdown).toHaveBeenCalled();
+    });
+
+    it("should throw on invalid startDate format", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "01/01/2024";
+        if (name === "endDate") return "2024-01-31";
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/startDate.*YYYY-MM-DD/);
+    });
+
+    it("should throw on invalid endDate format", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "2024-01-01";
+        if (name === "endDate") return "not-a-date";
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/endDate.*YYYY-MM-DD/);
+    });
+
+    it("should throw when startDate is after endDate", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "2024-02-01";
+        if (name === "endDate") return "2024-01-01";
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/startDate.*endDate/);
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -310,6 +310,7 @@ describe("ActualBudget", () => {
       });
 
       await expect(node.execute.call(executeFunctions)).rejects.toThrow(/startDate.*YYYY-MM-DD/);
+      expect(actualApi.getTransactions).not.toHaveBeenCalled();
     });
 
     it("should throw on invalid endDate format", async () => {
@@ -323,6 +324,7 @@ describe("ActualBudget", () => {
       });
 
       await expect(node.execute.call(executeFunctions)).rejects.toThrow(/endDate.*YYYY-MM-DD/);
+      expect(actualApi.getTransactions).not.toHaveBeenCalled();
     });
 
     it("should throw when startDate is after endDate", async () => {
@@ -336,6 +338,7 @@ describe("ActualBudget", () => {
       });
 
       await expect(node.execute.call(executeFunctions)).rejects.toThrow(/startDate.*endDate/);
+      expect(actualApi.getTransactions).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -21,6 +21,10 @@ vi.mock("@actual-app/api", () => ({
     totalBalance: 200000,
     categoryGroups: [],
   }),
+  getTransactions: vi.fn().mockResolvedValue([
+    { id: "tx-001", date: "2024-01-15", amount: -1000, account: "acc-1" },
+    { id: "tx-002", date: "2024-01-20", amount: -500, account: "acc-1" },
+  ]),
   setBudgetAmount: vi.fn().mockResolvedValue(undefined),
   shutdown: vi.fn().mockResolvedValue(undefined),
 }));
@@ -197,6 +201,102 @@ describe("ActualBudget", () => {
     const result = await node.execute.call(executeFunctions);
 
     expect(result[0][0].json).toEqual(importResult);
+  });
+
+  describe("getTransactions operation", () => {
+    it("should call getTransactions with correct accountId, startDate, and endDate", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "2024-01-01";
+        if (name === "endDate") return "2024-01-31";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.getTransactions).toHaveBeenCalledWith("acc-abc", "2024-01-01", "2024-01-31");
+    });
+
+    it("should return each transaction as a separate output item", async () => {
+      const transactions = [
+        { id: "tx-1", date: "2024-01-10", amount: -2000, account: "acc-abc" },
+        { id: "tx-2", date: "2024-01-15", amount: -3000, account: "acc-abc" },
+        { id: "tx-3", date: "2024-01-20", amount: 5000, account: "acc-abc" },
+      ];
+      vi.mocked(actualApi.getTransactions).mockResolvedValueOnce(transactions as unknown);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "2024-01-01";
+        if (name === "endDate") return "2024-01-31";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(result[0]).toHaveLength(3);
+      expect(result[0][0].json).toEqual(transactions[0]);
+      expect(result[0][1].json).toEqual(transactions[1]);
+      expect(result[0][2].json).toEqual(transactions[2]);
+    });
+
+    it("should return empty output when no transactions found", async () => {
+      vi.mocked(actualApi.getTransactions).mockResolvedValueOnce([]);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "2024-01-01";
+        if (name === "endDate") return "2024-01-31";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(result[0]).toHaveLength(0);
+    });
+
+    it("should call getTransactions once per input item", async () => {
+      const items = [
+        { accountId: "acc-1", startDate: "2024-01-01", endDate: "2024-01-31" },
+        { accountId: "acc-2", startDate: "2024-02-01", endDate: "2024-02-29" },
+      ];
+      executeFunctions.getInputData.mockReturnValue(items.map(() => ({ json: {} })));
+      executeFunctions.getNodeParameter.mockImplementation((name: string, itemIndex: number) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return items[itemIndex].accountId;
+        if (name === "startDate") return items[itemIndex].startDate;
+        if (name === "endDate") return items[itemIndex].endDate;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.getTransactions).toHaveBeenCalledTimes(2);
+      expect(actualApi.getTransactions).toHaveBeenNthCalledWith(1, "acc-1", "2024-01-01", "2024-01-31");
+      expect(actualApi.getTransactions).toHaveBeenNthCalledWith(2, "acc-2", "2024-02-01", "2024-02-29");
+    });
+
+    it("should call shutdown before re-throwing on getTransactions error", async () => {
+      vi.mocked(actualApi.getTransactions).mockRejectedValueOnce(new Error("account not found"));
+      executeFunctions.continueOnFail.mockReturnValue(false);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "2024-01-01";
+        if (name === "endDate") return "2024-01-31";
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow("account not found");
+
+      expect(actualApi.shutdown).toHaveBeenCalled();
+    });
   });
 
   describe("getBudgetMonth operation", () => {

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -340,6 +340,23 @@ describe("ActualBudget", () => {
       await expect(node.execute.call(executeFunctions)).rejects.toThrow(/startDate.*endDate/);
       expect(actualApi.getTransactions).not.toHaveBeenCalled();
     });
+
+    it("should capture validation error in output when continueOnFail=true", async () => {
+      executeFunctions.continueOnFail.mockReturnValue(true);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-abc";
+        if (name === "startDate") return "01/01/2024";
+        if (name === "endDate") return "2024-01-31";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(result).toBeDefined();
+      expect(actualApi.getTransactions).not.toHaveBeenCalled();
+    });
   });
 
   describe("getBudgetMonth operation", () => {

--- a/tests/ActualBudgetIntegration.spec.ts
+++ b/tests/ActualBudgetIntegration.spec.ts
@@ -138,4 +138,36 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
     expect(category).toBeDefined();
     expect((category as Record<string, unknown>).budgeted).toBe(50000);
   }, 30000);
+
+  it("should get transactions via the node", async () => {
+    const node = new ActualBudget();
+    const executeFunctions = {
+      getInputData: () => [{ json: {} }],
+      getNodeParameter: (name: string) => {
+        if (name === "operation") return "getTransactions";
+        if (name === "budgetId") return budgetId;
+        if (name === "accountId") return accountId;
+        if (name === "startDate") return "2024-03-01";
+        if (name === "endDate") return "2024-03-31";
+        return undefined;
+      },
+      getCredentials: async () => ({ url: serverURL, password }),
+      continueOnFail: () => false,
+      helpers: {
+        returnJsonArray: (data: unknown) =>
+          Array.isArray(data)
+            ? data.map((d) => ({ json: d as IDataObject }))
+            : [{ json: data as IDataObject }],
+        constructExecutionMetaData: (data: unknown) => data,
+      },
+    } as unknown as IExecuteFunctions;
+
+    const result = await node.execute.call(executeFunctions);
+
+    // The "should import transactions via the node" test imported a transaction on 2024-03-01
+    expect(result[0].length).toBeGreaterThan(0);
+    const txn = result[0].find((item) => (item.json as Record<string, unknown>).notes === "Integration test transaction");
+    expect(txn).toBeDefined();
+    expect((txn!.json as Record<string, unknown>).amount).toBe(-2500);
+  }, 15000);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Get Transactions" operation to fetch transactions by account ID and inclusive date range (YYYY-MM-DD). startDate/endDate params shown only for this operation; transaction JSON input remains for import. Each returned transaction is emitted as an individual output item.

* **Bug Fixes / Validation**
  * Added date-format validation and enforcement that start ≤ end; invalid inputs produce errors and prevent calls. Ensures proper shutdown on failures before rethrowing.

* **Tests**
  * Added unit tests covering success, empty results, per-item calls, error handling, and invalid-date cases; added a (skipped) integration test for the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->