### PR TITLE
fix: serialize node executions to avoid racing @actual-app/api singleton

### DIFF
--- a/nodes/ActualBudget/ActualBudget.node.ts
+++ b/nodes/ActualBudget/ActualBudget.node.ts
@@ -220,46 +220,48 @@ async function runActualBudget(context: IExecuteFunctions): Promise<INodeExecuti
 	const auth = (await context.getCredentials('actualBudgetApi', 0)) as Credentials;
 	await initializeActualBudget(auth);
 
-	const budgetId = context.getNodeParameter('budgetId', 0) as string;
+	try {
+		const budgetId = context.getNodeParameter('budgetId', 0) as string;
 
-	await downloadBudget(budgetId);
+		await downloadBudget(budgetId);
 
-	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-		try {
-			let elementData;
-			switch (action) {
-				case 'getBudgetMonth':
-					elementData = await handleGetBudgetMonth(context, itemIndex);
-					returnData.push(elementData);
-					break;
-				case 'getTransactions':
-					returnData.push(...(await handleGetTransactions(context, itemIndex)));
-					break;
-				case 'importTransactions':
-					elementData = await handleBudgetImport(context, itemIndex);
-					returnData.push(elementData);
-					break;
-				case 'setBudgetAmount':
-					elementData = await handleSetBudgetAmount(context, itemIndex);
-					returnData.push(elementData);
-					break;
+		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+			try {
+				let elementData;
+				switch (action) {
+					case 'getBudgetMonth':
+						elementData = await handleGetBudgetMonth(context, itemIndex);
+						returnData.push(elementData);
+						break;
+					case 'getTransactions':
+						returnData.push(...(await handleGetTransactions(context, itemIndex)));
+						break;
+					case 'importTransactions':
+						elementData = await handleBudgetImport(context, itemIndex);
+						returnData.push(elementData);
+						break;
+					case 'setBudgetAmount':
+						elementData = await handleSetBudgetAmount(context, itemIndex);
+						returnData.push(elementData);
+						break;
+				}
+			} catch (error) {
+				if (context.continueOnFail()) {
+					const executionData = context.helpers.constructExecutionMetaData(
+						context.helpers.returnJsonArray({ error: error.message }),
+						{ itemData: { item: itemIndex } },
+					);
+					returnData.push(...executionData);
+					continue;
+				}
+				throw error;
 			}
-		} catch (error) {
-			if (context.continueOnFail()) {
-				const executionData = context.helpers.constructExecutionMetaData(
-					context.helpers.returnJsonArray({ error: error.message }),
-					{ itemData: { item: itemIndex } },
-				);
-				returnData.push(...executionData);
-				continue;
-			}
-			await shutdown();
-			throw error;
 		}
-	}
 
-	await shutdown();
-	return [context.helpers.returnJsonArray(returnData)];
+		return [context.helpers.returnJsonArray(returnData)];
+	} finally {
+		await shutdown();
+	}
 }
 
 async function handleGetTransactions(

--- a/nodes/ActualBudget/ActualBudget.node.ts
+++ b/nodes/ActualBudget/ActualBudget.node.ts
@@ -35,6 +35,21 @@ interface Credentials {
 	password: string;
 }
 
+// @actual-app/api stores its session (DB connection, sync clock) in a module-level
+// singleton shared by every execution of this node in the process. Running two
+// executions concurrently lets one's init()/shutdown() tear down state the other is
+// mid-operation on, so all executions are funneled through this queue to run one at a time.
+let executionQueue: Promise<unknown> = Promise.resolve();
+
+function runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+	const result = executionQueue.then(fn, fn);
+	executionQueue = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	return result;
+}
+
 export class ActualBudget implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'ActualBudget',
@@ -190,54 +205,61 @@ export class ActualBudget implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const items = this.getInputData();
-		const returnData = [];
-
-		const action = this.getNodeParameter('operation', 0) as string;
-		const auth = (await this.getCredentials('actualBudgetApi', 0)) as Credentials;
-		await initializeActualBudget(auth);
-
-		const budgetId = this.getNodeParameter('budgetId', 0) as string;
-
-		await downloadBudget(budgetId);
-
-		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-			try {
-				let elementData;
-				switch (action) {
-					case 'getBudgetMonth':
-						elementData = await handleGetBudgetMonth(this, itemIndex);
-						returnData.push(elementData);
-						break;
-					case 'getTransactions':
-						returnData.push(...(await handleGetTransactions(this, itemIndex)));
-						break;
-					case 'importTransactions':
-						elementData = await handleBudgetImport(this, itemIndex);
-						returnData.push(elementData);
-						break;
-					case 'setBudgetAmount':
-						elementData = await handleSetBudgetAmount(this, itemIndex);
-						returnData.push(elementData);
-						break;
-				}
-			} catch (error) {
-				if (this.continueOnFail()) {
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ error: error.message }),
-						{ itemData: { item: itemIndex } },
-					);
-					returnData.push(...executionData);
-					continue;
-				}
-				await shutdown();
-				throw error;
-			}
-		}
-
-		await shutdown();
-		return [this.helpers.returnJsonArray(returnData)];
+		// @actual-app/api keeps its session (DB connection, sync clock) in a module-level
+		// singleton, so two executions running at once in this process would tear down or
+		// reinitialize each other's state mid-operation. Serialize executions to avoid that.
+		return runExclusive(() => runActualBudget(this));
 	}
+}
+
+async function runActualBudget(context: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+	const items = context.getInputData();
+	const returnData = [];
+
+	const action = context.getNodeParameter('operation', 0) as string;
+	const auth = (await context.getCredentials('actualBudgetApi', 0)) as Credentials;
+	await initializeActualBudget(auth);
+
+	const budgetId = context.getNodeParameter('budgetId', 0) as string;
+
+	await downloadBudget(budgetId);
+
+	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+		try {
+			let elementData;
+			switch (action) {
+				case 'getBudgetMonth':
+					elementData = await handleGetBudgetMonth(context, itemIndex);
+					returnData.push(elementData);
+					break;
+				case 'getTransactions':
+					returnData.push(...(await handleGetTransactions(context, itemIndex)));
+					break;
+				case 'importTransactions':
+					elementData = await handleBudgetImport(context, itemIndex);
+					returnData.push(elementData);
+					break;
+				case 'setBudgetAmount':
+					elementData = await handleSetBudgetAmount(context, itemIndex);
+					returnData.push(elementData);
+					break;
+			}
+		} catch (error) {
+			if (context.continueOnFail()) {
+				const executionData = context.helpers.constructExecutionMetaData(
+					context.helpers.returnJsonArray({ error: error.message }),
+					{ itemData: { item: itemIndex } },
+				);
+				returnData.push(...executionData);
+				continue;
+			}
+			await shutdown();
+			throw error;
+		}
+	}
+
+	await shutdown();
+	return [context.helpers.returnJsonArray(returnData)];
 }
 
 async function handleGetTransactions(


### PR DESCRIPTION
@actual-app/api keeps its session (DB connection, sync clock) in a module-level singleton. Concurrent executions of this node in the same process could have one execution's init()/shutdown() tear down state another was mid-operation on, surfacing as crashes deep in the SDK's sync internals (e.g. reading .timestamp off an undefined clock).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for multiple budget-related actions run within the same process by ensuring executions run without overlapping session lifecycle interference.
  * Reduced intermittent session and shutdown issues during back-to-back or concurrent node runs.
  * Kept existing per-item error/“continue on fail” behavior intact while making execution results more consistent.
  * Ensured shutdown now happens reliably on both success and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->