### PR TITLE
fix: authenticate release workflow's main push with GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate Token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Needed for git describe and commit counting
+          # persist-credentials stays true (default) so the later raw
+          # `git push` in the Publish step authenticates as the app.
+          token: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Needed for git describe and commit counting
           persist-credentials: false
@@ -129,8 +129,8 @@ jobs:
           git commit -m "Release $NEW_VERSION [skip ci]"
           git tag $NEW_VERSION
 
-          # Push commit and tag, authenticating only for this push
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" main --tags
+          # Push commit and tag atomically, authenticating only for this push
+          git push --atomic "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" main --tags
 
           # Publish to NPM directly with provenance enabled
           # We use --ignore-scripts to bypass n8n-node's prerelease check which 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Needed for git describe and commit counting
-          # persist-credentials stays true (default) so the later raw
-          # `git push` in the Publish step authenticates as the app.
-          token: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -108,7 +106,7 @@ jobs:
       - name: Publish to NPM
         if: steps.check_version.outputs.SKIP_RELEASE != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_TOKEN: ${{ steps.generate_token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
         run: |
@@ -131,8 +129,8 @@ jobs:
           git commit -m "Release $NEW_VERSION [skip ci]"
           git tag $NEW_VERSION
 
-          # Push commit and tag
-          git push origin main --tags
+          # Push commit and tag, authenticating only for this push
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" main --tags
 
           # Publish to NPM directly with provenance enabled
           # We use --ignore-scripts to bypass n8n-node's prerelease check which 


### PR DESCRIPTION
## Summary
- The `sync-publish` job in `release.yml` pushes a version-bump commit directly to `main` on every push. The default `GITHUB_TOKEN` it used has no bypass rights on branch protection, so once `main` started requiring the `build` status check, this push started failing with `GH006: Protected branch update failed`.
- Switches the workflow to mint a token from the same GitHub App `nightly.yml` already uses for its own privileged pushes/merges, which does have the needed permissions.

## Incident context
- One run already failed this way (tag `26.7.1` got pushed but the `main` commit and `npm publish` did not — the tag was manually deleted since nothing was ever published under that version).

## Test plan
- [ ] Merge this PR, then manually trigger `Sync Version and Publish` (`workflow_dispatch`) and confirm it pushes to `main` and publishes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow’s authentication for publishing and pushing release changes using a GitHub App installation token.
  * Updated checkout behavior to use a pinned action, full repository history, and safer credential handling.
  * Adjusted the git push process to authenticate via token-based HTTPS, while keeping release behavior consistent (including handling of tags/atomic pushes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->