### PR TITLE
Fix release workflow re-tagging an already-released version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
           # scheduled run until then re-detects IS_RELEASE_COMMIT=true and lands here
           # again. Only tag+publish once; treat an already-existing tag as "already
           # released" rather than an error.
-          if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+          if git rev-parse -q --verify "refs/tags/$NEW_VERSION" >/dev/null 2>&1; then
             echo "Tag $NEW_VERSION already exists - already released, nothing to do."
             exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,16 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
         run: |
           NEW_VERSION=$(jq -r .version package.json)
+
+          # HEAD stays the release-PR merge commit until the next push to main, so every
+          # scheduled run until then re-detects IS_RELEASE_COMMIT=true and lands here
+          # again. Only tag+publish once; treat an already-existing tag as "already
+          # released" rather than an error.
+          if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+            echo "Tag $NEW_VERSION already exists - already released, nothing to do."
+            exit 0
+          fi
+
           echo "Tagging and publishing $NEW_VERSION"
 
           git config --global user.name 'github-actions[bot]'


### PR DESCRIPTION
## Summary
- The scheduled daily "Sync Version and Publish" run detects "this push is a just-merged release PR" by checking whether HEAD's commit has an associated PR labeled `release` — not by checking whether a release still needs to happen.
- HEAD stays that same commit until the next push to `main`, so every scheduled run in between re-detects `IS_RELEASE_COMMIT=true`, skips straight to "Tag and Publish", and fails on `fatal: tag '<version>' already exists`. Observed failing for 26.7.5's release commit: https://github.com/TheFehr/n8n-nodes-actual/actions/runs/28766076492
- Fix: skip tag+publish early (treat as "already released, nothing to do") if the tag already exists, instead of erroring.

## Test plan
- [x] YAML syntax validated
- Can't fully dry-run the scheduled workflow itself, but the added guard is a straightforward `git rev-parse <tag>` check before the existing tag/publish logic — the next scheduled run (or a manual `workflow_dispatch`) will confirm it now exits cleanly instead of failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate releases by skipping publish steps when the same version has already been released.
  * Improved release reliability by ensuring existing versions are detected before a new release is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->