### PR TITLE
Add Account/Category/Category Group/Payee lookups + searchable pickers

### DIFF
--- a/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
+++ b/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
@@ -14,13 +14,20 @@ import { init, downloadBudget, shutdown } from '@actual-app/api';
 
 import { runExclusive } from '../executionQueue';
 
-import { transactionOperation, transactionFields, executeTransaction } from './actions/transaction';
-import { budgetOperation, budgetFields, executeBudget } from './actions/budget';
+import { Credentials } from './GenericFunctions';
 
-interface Credentials {
-	url: string;
-	password: string;
-}
+import { accountOperation, accountFields, executeAccount } from './actions/account';
+import { budgetOperation, budgetFields, executeBudget } from './actions/budget';
+import { categoryOperation, categoryFields, executeCategory } from './actions/category';
+import {
+	categoryGroupOperation,
+	categoryGroupFields,
+	executeCategoryGroup,
+} from './actions/categoryGroup';
+import { payeeOperation, payeeFields, executePayee } from './actions/payee';
+import { transactionOperation, transactionFields, executeTransaction } from './actions/transaction';
+
+import { searchAccounts, searchCategories, searchCategoryGroups, searchPayees } from './methods/listSearch';
 
 export class ActualBudgetV2 implements INodeType {
 	description: INodeTypeDescription = {
@@ -59,8 +66,24 @@ export class ActualBudgetV2 implements INodeType {
 				noDataExpression: true,
 				options: [
 					{
+						name: 'Account',
+						value: 'account',
+					},
+					{
 						name: 'Budget',
 						value: 'budget',
+					},
+					{
+						name: 'Category',
+						value: 'category',
+					},
+					{
+						name: 'Category Group',
+						value: 'categoryGroup',
+					},
+					{
+						name: 'Payee',
+						value: 'payee',
 					},
 					{
 						name: 'Transaction',
@@ -70,18 +93,36 @@ export class ActualBudgetV2 implements INodeType {
 				default: 'transaction',
 				required: true,
 			},
-			transactionOperation,
+			accountOperation,
 			budgetOperation,
-			...transactionFields,
+			categoryOperation,
+			categoryGroupOperation,
+			payeeOperation,
+			transactionOperation,
+			...accountFields,
 			...budgetFields,
+			...categoryFields,
+			...categoryGroupFields,
+			...payeeFields,
+			...transactionFields,
 		],
 		usableAsTool: undefined,
+	};
+
+	methods = {
+		listSearch: {
+			searchAccounts,
+			searchCategories,
+			searchCategoryGroups,
+			searchPayees,
+		},
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		// @actual-app/api keeps its session (DB connection, sync clock) in a module-level
 		// singleton, so two executions running at once in this process would tear down or
-		// reinitialize each other's state mid-operation. Serialize executions to avoid that.
+		// reinitialize each other's state mid-operation. Serialize executions to avoid that
+		// - and V1 executions share this same queue (see ../executionQueue.ts).
 		const continueOnFail = this.continueOnFail();
 		return runExclusive(() => runActualBudget(this, continueOnFail));
 	}
@@ -92,7 +133,7 @@ async function runActualBudget(
 	continueOnFail: boolean,
 ): Promise<INodeExecutionData[][]> {
 	const items = context.getInputData();
-	const returnData = [];
+	const returnData: IDataObject[] = [];
 
 	const resource = context.getNodeParameter('resource', 0) as string;
 	const operation = context.getNodeParameter('operation', 0) as string;
@@ -148,10 +189,18 @@ async function dispatch(
 	operation: string,
 ): Promise<IDataObject | IDataObject[]> {
 	switch (resource) {
-		case 'transaction':
-			return executeTransaction(context, itemIndex, operation);
+		case 'account':
+			return executeAccount(context, itemIndex, operation);
 		case 'budget':
 			return executeBudget(context, itemIndex, operation);
+		case 'category':
+			return executeCategory(context, itemIndex, operation);
+		case 'categoryGroup':
+			return executeCategoryGroup(context, itemIndex, operation);
+		case 'payee':
+			return executePayee(context, itemIndex, operation);
+		case 'transaction':
+			return executeTransaction(context, itemIndex, operation);
 		default:
 			throw new NodeOperationError(context.getNode(), `Unknown resource "${resource}"`);
 	}

--- a/nodes/ActualBudget/v2/GenericFunctions.ts
+++ b/nodes/ActualBudget/v2/GenericFunctions.ts
@@ -1,0 +1,36 @@
+import { init, downloadBudget, shutdown } from '@actual-app/api';
+
+import { runExclusive } from '../executionQueue';
+
+export interface Credentials {
+	url: string;
+	password: string;
+}
+
+async function initializeActualBudget(auth: Credentials): Promise<void> {
+	await init({
+		serverURL: auth.url,
+		password: auth.password,
+	});
+}
+
+/**
+ * Runs `fn` against a freshly initialized+downloaded budget, serialized against every
+ * other execute()/listSearch call via runExclusive, and always shuts the session down
+ * afterwards.
+ */
+export async function withBudgetSession<T>(
+	auth: Credentials,
+	budgetId: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	return runExclusive(async () => {
+		await initializeActualBudget(auth);
+		try {
+			await downloadBudget(budgetId);
+			return await fn();
+		} finally {
+			await shutdown();
+		}
+	});
+}

--- a/nodes/ActualBudget/v2/actions/account.ts
+++ b/nodes/ActualBudget/v2/actions/account.ts
@@ -1,0 +1,38 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { getAccounts } from '@actual-app/api';
+
+export const accountOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['account'],
+		},
+	},
+	options: [
+		{
+			name: 'Get Many',
+			value: 'getAccounts',
+			action: 'Get all accounts',
+		},
+	],
+	default: 'getAccounts',
+};
+
+export const accountFields: INodeProperties[] = [];
+
+export async function executeAccount(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getAccounts':
+			return (await getAccounts()) as unknown as IDataObject[];
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown account operation "${operation}"`);
+	}
+}

--- a/nodes/ActualBudget/v2/actions/budget.ts
+++ b/nodes/ActualBudget/v2/actions/budget.ts
@@ -48,18 +48,35 @@ export const budgetFields: INodeProperties[] = [
 		},
 	},
 	{
-		displayName: 'Category ID',
+		displayName: 'Category',
 		name: 'categoryId',
-		type: 'string',
-		default: '',
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
 		required: true,
-		description: 'The ID of the budget category',
+		description: 'The budget category',
 		displayOptions: {
 			show: {
 				resource: ['budget'],
 				operation: ['setBudgetAmount'],
 			},
 		},
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: 'searchCategories',
+					searchable: true,
+				},
+			},
+			{
+				displayName: 'ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'e.g. 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
+			},
+		],
 	},
 	{
 		displayName: 'Amount',
@@ -105,7 +122,9 @@ async function handleSetBudgetAmount(
 	itemIndex: number,
 ): Promise<IDataObject> {
 	const month = context.getNodeParameter('month', itemIndex) as string;
-	const categoryId = context.getNodeParameter('categoryId', itemIndex) as string;
+	const categoryId = context.getNodeParameter('categoryId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
 	const amount = context.getNodeParameter('amount', itemIndex) as number;
 	if (!Number.isInteger(amount)) {
 		throw new NodeOperationError(context.getNode(), '"amount" must be an integer number of millicents');

--- a/nodes/ActualBudget/v2/actions/category.ts
+++ b/nodes/ActualBudget/v2/actions/category.ts
@@ -1,0 +1,41 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { getCategories } from '@actual-app/api';
+
+export const categoryOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['category'],
+		},
+	},
+	options: [
+		{
+			name: 'Get Many',
+			value: 'getCategories',
+			action: 'Get all categories',
+		},
+	],
+	default: 'getCategories',
+};
+
+export const categoryFields: INodeProperties[] = [];
+
+export async function executeCategory(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getCategories':
+			// Note: getCategories() can return a mix of category and category-group
+			// entities in one flat array depending on the budget's structure. Use the
+			// "Category Group" resource's Get Many if you need the clean nested shape.
+			return (await getCategories()) as unknown as IDataObject[];
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown category operation "${operation}"`);
+	}
+}

--- a/nodes/ActualBudget/v2/actions/categoryGroup.ts
+++ b/nodes/ActualBudget/v2/actions/categoryGroup.ts
@@ -1,0 +1,38 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { getCategoryGroups } from '@actual-app/api';
+
+export const categoryGroupOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['categoryGroup'],
+		},
+	},
+	options: [
+		{
+			name: 'Get Many',
+			value: 'getCategoryGroups',
+			action: 'Get all category groups',
+		},
+	],
+	default: 'getCategoryGroups',
+};
+
+export const categoryGroupFields: INodeProperties[] = [];
+
+export async function executeCategoryGroup(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getCategoryGroups':
+			return (await getCategoryGroups()) as unknown as IDataObject[];
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown category group operation "${operation}"`);
+	}
+}

--- a/nodes/ActualBudget/v2/actions/payee.ts
+++ b/nodes/ActualBudget/v2/actions/payee.ts
@@ -1,0 +1,38 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { getPayees } from '@actual-app/api';
+
+export const payeeOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['payee'],
+		},
+	},
+	options: [
+		{
+			name: 'Get Many',
+			value: 'getPayees',
+			action: 'Get all payees',
+		},
+	],
+	default: 'getPayees',
+};
+
+export const payeeFields: INodeProperties[] = [];
+
+export async function executePayee(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getPayees':
+			return (await getPayees()) as unknown as IDataObject[];
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown payee operation "${operation}"`);
+	}
+}

--- a/nodes/ActualBudget/v2/actions/transaction.ts
+++ b/nodes/ActualBudget/v2/actions/transaction.ts
@@ -46,11 +46,11 @@ export const transactionOperation: INodeProperties = {
 
 export const transactionFields: INodeProperties[] = [
 	{
-		displayName: 'Account ID',
-		description: 'The ID of the Account you are working on/with',
+		displayName: 'Account',
+		description: 'The Account you are working on/with',
 		name: 'accountId',
-		type: 'string',
-		default: '',
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
 		displayOptions: {
 			show: {
 				resource: ['transaction'],
@@ -58,6 +58,23 @@ export const transactionFields: INodeProperties[] = [
 			},
 		},
 		required: true,
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: 'searchAccounts',
+					searchable: true,
+				},
+			},
+			{
+				displayName: 'ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'e.g. 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
+			},
+		],
 	},
 	{
 		displayName: 'Start Date',
@@ -121,7 +138,9 @@ async function handleGetTransactions(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<IDataObject[]> {
-	const accountId = context.getNodeParameter('accountId', itemIndex) as string;
+	const accountId = context.getNodeParameter('accountId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
 	const startDate = context.getNodeParameter('startDate', itemIndex) as string;
 	const endDate = context.getNodeParameter('endDate', itemIndex) as string;
 	const datePattern = /^\d{4}-\d{2}-\d{2}$/;
@@ -141,7 +160,9 @@ async function handleImportTransactions(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<IDataObject> {
-	const accountId = context.getNodeParameter('accountId', itemIndex) as string;
+	const accountId = context.getNodeParameter('accountId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
 	const raw = context.getNodeParameter('transactions', itemIndex);
 	let parsed: unknown;
 	if (typeof raw === 'string') {

--- a/nodes/ActualBudget/v2/methods/listSearch.ts
+++ b/nodes/ActualBudget/v2/methods/listSearch.ts
@@ -1,0 +1,75 @@
+import { ILoadOptionsFunctions, INodeListSearchResult } from 'n8n-workflow';
+
+import { getAccounts, getCategoryGroups, getPayees } from '@actual-app/api';
+
+import { Credentials, withBudgetSession } from '../GenericFunctions';
+
+async function getAuthAndBudget(
+	context: ILoadOptionsFunctions,
+): Promise<{ auth: Credentials; budgetId: string }> {
+	const auth = (await context.getCredentials('actualBudgetApi')) as Credentials;
+	const budgetId = context.getNodeParameter('budgetId', 0) as string;
+	return { auth, budgetId };
+}
+
+function matchesFilter(name: string, filter?: string): boolean {
+	if (!filter) return true;
+	return name.toLowerCase().includes(filter.toLowerCase());
+}
+
+export async function searchAccounts(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const { auth, budgetId } = await getAuthAndBudget(this);
+	const accounts = await withBudgetSession(auth, budgetId, () => getAccounts());
+	return {
+		results: accounts
+			.filter((account) => matchesFilter(account.name, filter))
+			.map((account) => ({ name: account.name, value: account.id })),
+	};
+}
+
+export async function searchPayees(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const { auth, budgetId } = await getAuthAndBudget(this);
+	const payees = await withBudgetSession(auth, budgetId, () => getPayees());
+	return {
+		results: payees
+			.filter((payee) => matchesFilter(payee.name, filter))
+			.map((payee) => ({ name: payee.name, value: payee.id })),
+	};
+}
+
+// Categories are searched via their owning group (getCategoryGroups' nested shape) rather
+// than getCategories(), which can return a mix of category and category-group entities in
+// one flat array depending on the budget's structure.
+export async function searchCategories(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const { auth, budgetId } = await getAuthAndBudget(this);
+	const groups = await withBudgetSession(auth, budgetId, () => getCategoryGroups());
+	const results = groups.flatMap((group) =>
+		(group.categories ?? []).map((category) => ({
+			name: `${group.name} / ${category.name}`,
+			value: category.id,
+		})),
+	);
+	return { results: results.filter((result) => matchesFilter(result.name, filter)) };
+}
+
+export async function searchCategoryGroups(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const { auth, budgetId } = await getAuthAndBudget(this);
+	const groups = await withBudgetSession(auth, budgetId, () => getCategoryGroups());
+	return {
+		results: groups
+			.filter((group) => matchesFilter(group.name, filter))
+			.map((group) => ({ name: group.name, value: group.id })),
+	};
+}

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -675,8 +675,10 @@ describe("ActualBudget", () => {
       const result = await node.execute.call(executeFunctions);
 
       expect(actualApi.getAccounts).toHaveBeenCalled();
-      expect(result[0]).toHaveLength(2);
-      expect(result[0][0].json).toEqual({ id: "acc-1", name: "Checking" });
+      expect(result[0].map((item) => item.json)).toEqual([
+        { id: "acc-1", name: "Checking" },
+        { id: "acc-2", name: "Savings" },
+      ]);
     });
   });
 
@@ -710,7 +712,11 @@ describe("ActualBudget", () => {
 
       expect(actualApi.getCategoryGroups).toHaveBeenCalled();
       expect(result[0]).toHaveLength(1);
-      expect((result[0][0].json as IDataObject).name).toBe("Food");
+      expect(result[0][0].json).toEqual({
+        id: "grp-1",
+        name: "Food",
+        categories: [{ id: "cat-1", name: "Groceries" }],
+      });
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -27,6 +27,19 @@ vi.mock("@actual-app/api", () => ({
   ]),
   setBudgetAmount: vi.fn().mockResolvedValue(undefined),
   shutdown: vi.fn().mockResolvedValue(undefined),
+  getAccounts: vi.fn().mockResolvedValue([
+    { id: "acc-1", name: "Checking" },
+    { id: "acc-2", name: "Savings" },
+  ]),
+  getCategories: vi.fn().mockResolvedValue([
+    { id: "cat-1", name: "Groceries", group_id: "grp-1" },
+  ]),
+  getCategoryGroups: vi.fn().mockResolvedValue([
+    { id: "grp-1", name: "Food", categories: [{ id: "cat-1", name: "Groceries" }] },
+  ]),
+  getPayees: vi.fn().mockResolvedValue([
+    { id: "payee-1", name: "Landlord" },
+  ]),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -647,6 +660,74 @@ describe("ActualBudget", () => {
 
       expect(result).toBeDefined();
       expect(actualApi.shutdown).toHaveBeenCalled();
+    });
+  });
+
+  describe("account resource", () => {
+    it("should call getAccounts and return each account as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getAccounts";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getAccounts).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(2);
+      expect(result[0][0].json).toEqual({ id: "acc-1", name: "Checking" });
+    });
+  });
+
+  describe("category resource", () => {
+    it("should call getCategories and return each category as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getCategories";
+        if (name === "resource") return "category";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getCategories).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+      expect(result[0][0].json).toEqual({ id: "cat-1", name: "Groceries", group_id: "grp-1" });
+    });
+  });
+
+  describe("categoryGroup resource", () => {
+    it("should call getCategoryGroups and return each group as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getCategoryGroups";
+        if (name === "resource") return "categoryGroup";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getCategoryGroups).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+      expect((result[0][0].json as IDataObject).name).toBe("Food");
+    });
+  });
+
+  describe("payee resource", () => {
+    it("should call getPayees and return each payee as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getPayees";
+        if (name === "resource") return "payee";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getPayees).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+      expect(result[0][0].json).toEqual({ id: "payee-1", name: "Landlord" });
     });
   });
 

--- a/tests/listSearch.spec.ts
+++ b/tests/listSearch.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ILoadOptionsFunctions } from "n8n-workflow";
+
+vi.mock("@actual-app/api", () => ({
+  init: vi.fn().mockResolvedValue(undefined),
+  downloadBudget: vi.fn().mockResolvedValue(undefined),
+  shutdown: vi.fn().mockResolvedValue(undefined),
+  getAccounts: vi.fn().mockResolvedValue([
+    { id: "acc-1", name: "Checking" },
+    { id: "acc-2", name: "Savings" },
+  ]),
+  getPayees: vi.fn().mockResolvedValue([
+    { id: "payee-1", name: "Landlord" },
+    { id: "payee-2", name: "Electric Co" },
+  ]),
+  getCategoryGroups: vi.fn().mockResolvedValue([
+    {
+      id: "grp-1",
+      name: "Food",
+      categories: [
+        { id: "cat-1", name: "Groceries" },
+        { id: "cat-2", name: "Restaurants" },
+      ],
+    },
+    { id: "grp-2", name: "Bills", categories: [{ id: "cat-3", name: "Electricity" }] },
+  ]),
+}));
+
+import { searchAccounts, searchPayees, searchCategories, searchCategoryGroups } from "../nodes/ActualBudget/v2/methods/listSearch";
+
+function makeLoadOptionsContext(budgetId: string): ILoadOptionsFunctions {
+  return {
+    getCredentials: vi.fn().mockResolvedValue({ url: "http://localhost:5006", password: "test-password" }),
+    getNodeParameter: vi.fn().mockReturnValue(budgetId),
+  } as unknown as ILoadOptionsFunctions;
+}
+
+describe("listSearch methods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("searchAccounts returns all accounts mapped to name/value when no filter given", async () => {
+    const result = await searchAccounts.call(makeLoadOptionsContext("budget-1"));
+    expect(result.results).toEqual([
+      { name: "Checking", value: "acc-1" },
+      { name: "Savings", value: "acc-2" },
+    ]);
+  });
+
+  it("searchAccounts filters case-insensitively by name", async () => {
+    const result = await searchAccounts.call(makeLoadOptionsContext("budget-1"), "check");
+    expect(result.results).toEqual([{ name: "Checking", value: "acc-1" }]);
+  });
+
+  it("searchPayees returns all payees mapped to name/value", async () => {
+    const result = await searchPayees.call(makeLoadOptionsContext("budget-1"));
+    expect(result.results).toEqual([
+      { name: "Landlord", value: "payee-1" },
+      { name: "Electric Co", value: "payee-2" },
+    ]);
+  });
+
+  it("searchCategoryGroups returns all groups mapped to name/value", async () => {
+    const result = await searchCategoryGroups.call(makeLoadOptionsContext("budget-1"));
+    expect(result.results).toEqual([
+      { name: "Food", value: "grp-1" },
+      { name: "Bills", value: "grp-2" },
+    ]);
+  });
+
+  it("searchCategories flattens categories under their group name and filters by category name", async () => {
+    const result = await searchCategories.call(makeLoadOptionsContext("budget-1"), "grocer");
+    expect(result.results).toEqual([{ name: "Food / Groceries", value: "cat-1" }]);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on #215.

- New resources: `Account`, `Category`, `Category Group`, `Payee`, each with a `Get Many` operation (`getAccounts`/`getCategories`/`getCategoryGroups`/`getPayees`).
- Converts the existing `accountId` (Transaction) and `categoryId` (Budget) fields to `resourceLocator`, backed by new `listSearch` methods (`searchAccounts`, `searchCategories`, `searchCategoryGroups`, `searchPayees`) — users can now search by name in the UI instead of pasting raw Actual IDs.
- Extracts session lifecycle (`init`/`downloadBudget`/`shutdown` + the cross-execution serialization queue) into `GenericFunctions.ts` so `execute()` and the new `listSearch` methods share one implementation.
- `searchCategories` reads through `getCategoryGroups()`'s nested shape rather than `getCategories()`, since the latter can return a mix of category and category-group entities in one flat array depending on the budget's structure.

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 44 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds
- [ ] Manual: verify in a local n8n instance that the Account/Category resourceLocator dropdowns populate and search correctly against a real budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving accounts, categories, category groups, and payees from Actual Budget.
  * Added searchable selectors for accounts, categories, category groups, payees, budget categories, and transaction accounts.
  * Category searches now display group and category names.
* **Improvements**
  * Improved error handling for unsupported operations and resource validation.
* **Tests**
  * Added coverage for new resources, search filtering, result mapping, and separate output items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->