### PR TITLE
Add full Account CRUD operations

### DIFF
--- a/nodes/ActualBudget/v2/GenericFunctions.ts
+++ b/nodes/ActualBudget/v2/GenericFunctions.ts
@@ -1,3 +1,5 @@
+import { IDisplayOptions, INodeProperties } from 'n8n-workflow';
+
 import { init, downloadBudget, shutdown } from '@actual-app/api';
 
 import { runExclusive } from '../executionQueue';
@@ -5,6 +7,46 @@ import { runExclusive } from '../executionQueue';
 export interface Credentials {
 	url: string;
 	password: string;
+}
+
+/**
+ * Builds a resourceLocator field with the standard "search by name" / "paste a raw ID"
+ * modes used throughout this node (Account, Category, Category Group, Payee, ...).
+ */
+export function resourceLocatorField(options: {
+	displayName: string;
+	name: string;
+	searchListMethod: string;
+	displayOptions: IDisplayOptions;
+	description?: string;
+	required?: boolean;
+}): INodeProperties {
+	return {
+		displayName: options.displayName,
+		name: options.name,
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
+		required: options.required,
+		description: options.description,
+		displayOptions: options.displayOptions,
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: options.searchListMethod,
+					searchable: true,
+				},
+			},
+			{
+				displayName: 'ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'e.g. 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
+			},
+		],
+	};
 }
 
 async function initializeActualBudget(auth: Credentials): Promise<void> {
@@ -16,8 +58,8 @@ async function initializeActualBudget(auth: Credentials): Promise<void> {
 
 /**
  * Runs `fn` against a freshly initialized+downloaded budget, serialized against every
- * other execute()/listSearch call via runExclusive, and always shuts the session down
- * afterwards.
+ * other execute()/listSearch call via the shared runExclusive queue, and always shuts the
+ * session down afterwards.
  */
 export async function withBudgetSession<T>(
 	auth: Credentials,

--- a/nodes/ActualBudget/v2/actions/account.ts
+++ b/nodes/ActualBudget/v2/actions/account.ts
@@ -1,6 +1,16 @@
 import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
 
-import { getAccounts } from '@actual-app/api';
+import {
+	closeAccount,
+	createAccount,
+	deleteAccount,
+	getAccountBalance,
+	getAccounts,
+	reopenAccount,
+	updateAccount,
+} from '@actual-app/api';
+
+import { resourceLocatorField } from '../GenericFunctions';
 
 export const accountOperation: INodeProperties = {
 	displayName: 'Operation',
@@ -14,15 +24,165 @@ export const accountOperation: INodeProperties = {
 	},
 	options: [
 		{
+			name: 'Close',
+			value: 'closeAccount',
+			action: 'Close an account',
+		},
+		{
+			name: 'Create',
+			value: 'createAccount',
+			action: 'Create an account',
+		},
+		{
+			name: 'Delete',
+			value: 'deleteAccount',
+			action: 'Delete an account',
+		},
+		{
+			name: 'Get Balance',
+			value: 'getAccountBalance',
+			action: 'Get the balance of an account',
+		},
+		{
 			name: 'Get Many',
 			value: 'getAccounts',
 			action: 'Get all accounts',
+		},
+		{
+			name: 'Reopen',
+			value: 'reopenAccount',
+			action: 'Reopen a closed account',
+		},
+		{
+			name: 'Update',
+			value: 'updateAccount',
+			action: 'Update an account',
 		},
 	],
 	default: 'getAccounts',
 };
 
-export const accountFields: INodeProperties[] = [];
+const accountLocator = (operations: string[]) =>
+	resourceLocatorField({
+		displayName: 'Account',
+		name: 'accountId',
+		description: 'The Account to operate on',
+		searchListMethod: 'searchAccounts',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: operations,
+			},
+		},
+	});
+
+export const accountFields: INodeProperties[] = [
+	accountLocator(['updateAccount', 'closeAccount', 'reopenAccount', 'deleteAccount', 'getAccountBalance']),
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['createAccount'],
+			},
+		},
+	},
+	{
+		displayName: 'Off Budget',
+		name: 'offbudget',
+		type: 'boolean',
+		default: false,
+		description: 'Whether the account is off-budget (e.g. a tracking/investment account)',
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['createAccount'],
+			},
+		},
+	},
+	{
+		displayName: 'Initial Balance',
+		name: 'initialBalance',
+		type: 'number',
+		default: 0,
+		description: 'Initial account balance, in cents',
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['createAccount'],
+			},
+		},
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['updateAccount'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Off Budget',
+				name: 'offbudget',
+				type: 'boolean',
+				default: false,
+			},
+		],
+	},
+	resourceLocatorField({
+		displayName: 'Transfer Account',
+		name: 'transferAccountId',
+		description: 'Account to transfer this account\'s balance to on close, if any',
+		searchListMethod: 'searchAccounts',
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['closeAccount'],
+			},
+		},
+	}),
+	resourceLocatorField({
+		displayName: 'Transfer Category',
+		name: 'transferCategoryId',
+		description: 'Category to assign the transferred balance to, if any',
+		searchListMethod: 'searchCategories',
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['closeAccount'],
+			},
+		},
+	}),
+	{
+		displayName: 'Cutoff Date',
+		name: 'cutoff',
+		type: 'dateTime',
+		default: '',
+		description: 'Only count transactions up to this date, if set',
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['getAccountBalance'],
+			},
+		},
+	},
+];
 
 export async function executeAccount(
 	context: IExecuteFunctions,
@@ -32,7 +192,87 @@ export async function executeAccount(
 	switch (operation) {
 		case 'getAccounts':
 			return (await getAccounts()) as unknown as IDataObject[];
+		case 'createAccount':
+			return handleCreateAccount(context, itemIndex);
+		case 'updateAccount':
+			return handleUpdateAccount(context, itemIndex);
+		case 'closeAccount':
+			return handleCloseAccount(context, itemIndex);
+		case 'reopenAccount':
+			return handleReopenAccount(context, itemIndex);
+		case 'deleteAccount':
+			return handleDeleteAccount(context, itemIndex);
+		case 'getAccountBalance':
+			return handleGetAccountBalance(context, itemIndex);
 		default:
 			throw new NodeOperationError(context.getNode(), `Unknown account operation "${operation}"`);
 	}
+}
+
+function getAccountId(context: IExecuteFunctions, itemIndex: number): string {
+	return context.getNodeParameter('accountId', itemIndex, undefined, { extractValue: true }) as string;
+}
+
+async function handleCreateAccount(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const name = context.getNodeParameter('name', itemIndex) as string;
+	const offbudget = context.getNodeParameter('offbudget', itemIndex) as boolean;
+	const initialBalance = context.getNodeParameter('initialBalance', itemIndex) as number;
+	const id = await createAccount({ name, offbudget }, initialBalance);
+	return { id, name, offbudget };
+}
+
+async function handleUpdateAccount(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getAccountId(context, itemIndex);
+	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+	await updateAccount(id, fields);
+	return { success: true, id, ...fields };
+}
+
+async function handleCloseAccount(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getAccountId(context, itemIndex);
+	const transferAccountId = context.getNodeParameter('transferAccountId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	const transferCategoryId = context.getNodeParameter('transferCategoryId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	await closeAccount(id, transferAccountId || undefined, transferCategoryId || undefined);
+	return { success: true, id };
+}
+
+async function handleReopenAccount(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getAccountId(context, itemIndex);
+	await reopenAccount(id);
+	return { success: true, id };
+}
+
+async function handleDeleteAccount(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getAccountId(context, itemIndex);
+	await deleteAccount(id);
+	return { success: true, id };
+}
+
+async function handleGetAccountBalance(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getAccountId(context, itemIndex);
+	const cutoff = context.getNodeParameter('cutoff', itemIndex) as string;
+	const balance = await getAccountBalance(id, cutoff ? new Date(cutoff) : undefined);
+	return { id, balance };
 }

--- a/nodes/ActualBudget/v2/actions/budget.ts
+++ b/nodes/ActualBudget/v2/actions/budget.ts
@@ -7,6 +7,8 @@ import {
 
 import { getBudgetMonth, setBudgetAmount } from '@actual-app/api';
 
+import { resourceLocatorField } from '../GenericFunctions';
+
 export const budgetOperation: INodeProperties = {
 	displayName: 'Operation',
 	name: 'operation',
@@ -47,37 +49,19 @@ export const budgetFields: INodeProperties[] = [
 			},
 		},
 	},
-	{
+	resourceLocatorField({
 		displayName: 'Category',
 		name: 'categoryId',
-		type: 'resourceLocator',
-		default: { mode: 'list', value: '' },
-		required: true,
 		description: 'The budget category',
+		searchListMethod: 'searchCategories',
+		required: true,
 		displayOptions: {
 			show: {
 				resource: ['budget'],
 				operation: ['setBudgetAmount'],
 			},
 		},
-		modes: [
-			{
-				displayName: 'From List',
-				name: 'list',
-				type: 'list',
-				typeOptions: {
-					searchListMethod: 'searchCategories',
-					searchable: true,
-				},
-			},
-			{
-				displayName: 'ID',
-				name: 'id',
-				type: 'string',
-				placeholder: 'e.g. 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
-			},
-		],
-	},
+	}),
 	{
 		displayName: 'Amount',
 		name: 'amount',

--- a/nodes/ActualBudget/v2/actions/transaction.ts
+++ b/nodes/ActualBudget/v2/actions/transaction.ts
@@ -7,6 +7,8 @@ import {
 
 import { getTransactions, importTransactions } from '@actual-app/api';
 
+import { resourceLocatorField } from '../GenericFunctions';
+
 export interface ActualTransaction {
 	date: string;
 	amount: number;
@@ -45,37 +47,19 @@ export const transactionOperation: INodeProperties = {
 };
 
 export const transactionFields: INodeProperties[] = [
-	{
+	resourceLocatorField({
 		displayName: 'Account',
-		description: 'The Account you are working on/with',
 		name: 'accountId',
-		type: 'resourceLocator',
-		default: { mode: 'list', value: '' },
+		description: 'The Account you are working on/with',
+		searchListMethod: 'searchAccounts',
+		required: true,
 		displayOptions: {
 			show: {
 				resource: ['transaction'],
 				operation: ['importTransactions', 'getTransactions'],
 			},
 		},
-		required: true,
-		modes: [
-			{
-				displayName: 'From List',
-				name: 'list',
-				type: 'list',
-				typeOptions: {
-					searchListMethod: 'searchAccounts',
-					searchable: true,
-				},
-			},
-			{
-				displayName: 'ID',
-				name: 'id',
-				type: 'string',
-				placeholder: 'e.g. 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
-			},
-		],
-	},
+	}),
 	{
 		displayName: 'Start Date',
 		name: 'startDate',

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -40,6 +40,12 @@ vi.mock("@actual-app/api", () => ({
   getPayees: vi.fn().mockResolvedValue([
     { id: "payee-1", name: "Landlord" },
   ]),
+  createAccount: vi.fn().mockResolvedValue("acc-new"),
+  updateAccount: vi.fn().mockResolvedValue(undefined),
+  closeAccount: vi.fn().mockResolvedValue(undefined),
+  reopenAccount: vi.fn().mockResolvedValue(undefined),
+  deleteAccount: vi.fn().mockResolvedValue(undefined),
+  getAccountBalance: vi.fn().mockResolvedValue(123400),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -679,6 +685,119 @@ describe("ActualBudget", () => {
         { id: "acc-1", name: "Checking" },
         { id: "acc-2", name: "Savings" },
       ]);
+    });
+
+    it("should call createAccount with name, offbudget, and initialBalance", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createAccount";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "New Account";
+        if (name === "offbudget") return true;
+        if (name === "initialBalance") return 5000;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.createAccount).toHaveBeenCalledWith(
+        { name: "New Account", offbudget: true },
+        5000,
+      );
+      expect(result[0][0].json).toEqual({ id: "acc-new", name: "New Account", offbudget: true });
+    });
+
+    it("should call updateAccount with the resolved account ID and update fields", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateAccount";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-1";
+        if (name === "updateFields") return { name: "Renamed" };
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateAccount).toHaveBeenCalledWith("acc-1", { name: "Renamed" });
+    });
+
+    it("should call closeAccount with transfer account/category when provided", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "closeAccount";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-1";
+        if (name === "transferAccountId") return "acc-2";
+        if (name === "transferCategoryId") return "cat-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.closeAccount).toHaveBeenCalledWith("acc-1", "acc-2", "cat-1");
+    });
+
+    it("should call reopenAccount with the resolved account ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "reopenAccount";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.reopenAccount).toHaveBeenCalledWith("acc-1");
+    });
+
+    it("should call deleteAccount with the resolved account ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deleteAccount";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.deleteAccount).toHaveBeenCalledWith("acc-1");
+    });
+
+    it("should call getAccountBalance with the resolved account ID and no cutoff when unset", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getAccountBalance";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-1";
+        if (name === "cutoff") return "";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getAccountBalance).toHaveBeenCalledWith("acc-1", undefined);
+      expect(result[0][0].json).toEqual({ id: "acc-1", balance: 123400 });
+    });
+
+    it("should call getAccountBalance with a cutoff Date when provided", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getAccountBalance";
+        if (name === "resource") return "account";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-1";
+        if (name === "cutoff") return "2024-03-01T00:00:00.000Z";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.getAccountBalance).toHaveBeenCalledWith(
+        "acc-1",
+        new Date("2024-03-01T00:00:00.000Z"),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
Stacked on #216.

- Adds `Create`, `Update`, `Close`, `Reopen`, `Delete`, and `Get Balance` operations to the Account resource, wrapping `createAccount`/`updateAccount`/`closeAccount`/`reopenAccount`/`deleteAccount`/`getAccountBalance`.
- Extracts `resourceLocatorField()` into `GenericFunctions.ts` (the "From List"/"ID" mode boilerplate was about to be duplicated a third time) and migrates the existing Transaction/Budget resourceLocator fields to use it — no behavior change to those.

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 51 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account management operations, including create, update, close, reopen, delete, and balance retrieval.
  * Added account selection, transfer options, and optional balance cutoff date configuration.
  * Improved resource selection with searchable lists and raw-ID entry options.

* **Bug Fixes**
  * Standardized resource selectors for budget categories and transaction accounts.

* **Tests**
  * Added coverage for account lifecycle operations and balance lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->