### PR TITLE
Add Category and Category Group CRUD

### DIFF
--- a/nodes/ActualBudget/v2/actions/category.ts
+++ b/nodes/ActualBudget/v2/actions/category.ts
@@ -117,10 +117,17 @@ export const categoryFields: INodeProperties[] = [
 		},
 		options: [
 			{
-				displayName: 'Name',
-				name: 'name',
+				displayName: 'Category Group ID',
+				name: 'group_id',
 				type: 'string',
 				default: '',
+				description: 'Move this category to a different Category Group (see the Category Group "Get Many" operation to look up its ID)',
+			},
+			{
+				displayName: 'Hidden',
+				name: 'hidden',
+				type: 'boolean',
+				default: false,
 			},
 			{
 				displayName: 'Is Income',
@@ -129,10 +136,10 @@ export const categoryFields: INodeProperties[] = [
 				default: false,
 			},
 			{
-				displayName: 'Hidden',
-				name: 'hidden',
-				type: 'boolean',
-				default: false,
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
 			},
 		],
 	},

--- a/nodes/ActualBudget/v2/actions/category.ts
+++ b/nodes/ActualBudget/v2/actions/category.ts
@@ -1,6 +1,8 @@
 import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
 
-import { getCategories } from '@actual-app/api';
+import { createCategory, deleteCategory, getCategories, updateCategory } from '@actual-app/api';
+
+import { resourceLocatorField } from '../GenericFunctions';
 
 export const categoryOperation: INodeProperties = {
 	displayName: 'Operation',
@@ -14,15 +16,139 @@ export const categoryOperation: INodeProperties = {
 	},
 	options: [
 		{
+			name: 'Create',
+			value: 'createCategory',
+			action: 'Create a category',
+		},
+		{
+			name: 'Delete',
+			value: 'deleteCategory',
+			action: 'Delete a category',
+		},
+		{
 			name: 'Get Many',
 			value: 'getCategories',
 			action: 'Get all categories',
+		},
+		{
+			name: 'Update',
+			value: 'updateCategory',
+			action: 'Update a category',
 		},
 	],
 	default: 'getCategories',
 };
 
-export const categoryFields: INodeProperties[] = [];
+export const categoryFields: INodeProperties[] = [
+	resourceLocatorField({
+		displayName: 'Category',
+		name: 'categoryId',
+		description: 'The Category to operate on',
+		searchListMethod: 'searchCategories',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['category'],
+				operation: ['updateCategory', 'deleteCategory'],
+			},
+		},
+	}),
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['category'],
+				operation: ['createCategory'],
+			},
+		},
+	},
+	resourceLocatorField({
+		displayName: 'Category Group',
+		name: 'groupId',
+		description: 'The Category Group this category belongs to',
+		searchListMethod: 'searchCategoryGroups',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['category'],
+				operation: ['createCategory'],
+			},
+		},
+	}),
+	{
+		displayName: 'Is Income',
+		name: 'is_income',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['category'],
+				operation: ['createCategory'],
+			},
+		},
+	},
+	{
+		displayName: 'Hidden',
+		name: 'hidden',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['category'],
+				operation: ['createCategory'],
+			},
+		},
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['category'],
+				operation: ['updateCategory'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Is Income',
+				name: 'is_income',
+				type: 'boolean',
+				default: false,
+			},
+			{
+				displayName: 'Hidden',
+				name: 'hidden',
+				type: 'boolean',
+				default: false,
+			},
+		],
+	},
+	resourceLocatorField({
+		displayName: 'Transfer Category',
+		name: 'transferCategoryId',
+		description: 'Category to reassign this category\'s budget history to on delete, if any',
+		searchListMethod: 'searchCategories',
+		displayOptions: {
+			show: {
+				resource: ['category'],
+				operation: ['deleteCategory'],
+			},
+		},
+	}),
+];
 
 export async function executeCategory(
 	context: IExecuteFunctions,
@@ -35,7 +161,53 @@ export async function executeCategory(
 			// entities in one flat array depending on the budget's structure. Use the
 			// "Category Group" resource's Get Many if you need the clean nested shape.
 			return (await getCategories()) as unknown as IDataObject[];
+		case 'createCategory':
+			return handleCreateCategory(context, itemIndex);
+		case 'updateCategory':
+			return handleUpdateCategory(context, itemIndex);
+		case 'deleteCategory':
+			return handleDeleteCategory(context, itemIndex);
 		default:
 			throw new NodeOperationError(context.getNode(), `Unknown category operation "${operation}"`);
 	}
+}
+
+function getCategoryId(context: IExecuteFunctions, itemIndex: number): string {
+	return context.getNodeParameter('categoryId', itemIndex, undefined, { extractValue: true }) as string;
+}
+
+async function handleCreateCategory(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const name = context.getNodeParameter('name', itemIndex) as string;
+	const groupId = context.getNodeParameter('groupId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	const is_income = context.getNodeParameter('is_income', itemIndex) as boolean;
+	const hidden = context.getNodeParameter('hidden', itemIndex) as boolean;
+	const id = await createCategory({ name, group_id: groupId, is_income, hidden });
+	return { id, name, group_id: groupId, is_income, hidden };
+}
+
+async function handleUpdateCategory(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getCategoryId(context, itemIndex);
+	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+	await updateCategory(id, fields);
+	return { success: true, id, ...fields };
+}
+
+async function handleDeleteCategory(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getCategoryId(context, itemIndex);
+	const transferCategoryId = context.getNodeParameter('transferCategoryId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	await deleteCategory(id, transferCategoryId || undefined);
+	return { success: true, id };
 }

--- a/nodes/ActualBudget/v2/actions/categoryGroup.ts
+++ b/nodes/ActualBudget/v2/actions/categoryGroup.ts
@@ -1,6 +1,13 @@
 import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
 
-import { getCategoryGroups } from '@actual-app/api';
+import {
+	createCategoryGroup,
+	deleteCategoryGroup,
+	getCategoryGroups,
+	updateCategoryGroup,
+} from '@actual-app/api';
+
+import { resourceLocatorField } from '../GenericFunctions';
 
 export const categoryGroupOperation: INodeProperties = {
 	displayName: 'Operation',
@@ -14,15 +21,126 @@ export const categoryGroupOperation: INodeProperties = {
 	},
 	options: [
 		{
+			name: 'Create',
+			value: 'createCategoryGroup',
+			action: 'Create a category group',
+		},
+		{
+			name: 'Delete',
+			value: 'deleteCategoryGroup',
+			action: 'Delete a category group',
+		},
+		{
 			name: 'Get Many',
 			value: 'getCategoryGroups',
 			action: 'Get all category groups',
+		},
+		{
+			name: 'Update',
+			value: 'updateCategoryGroup',
+			action: 'Update a category group',
 		},
 	],
 	default: 'getCategoryGroups',
 };
 
-export const categoryGroupFields: INodeProperties[] = [];
+export const categoryGroupFields: INodeProperties[] = [
+	resourceLocatorField({
+		displayName: 'Category Group',
+		name: 'categoryGroupId',
+		description: 'The Category Group to operate on',
+		searchListMethod: 'searchCategoryGroups',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['categoryGroup'],
+				operation: ['updateCategoryGroup', 'deleteCategoryGroup'],
+			},
+		},
+	}),
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['categoryGroup'],
+				operation: ['createCategoryGroup'],
+			},
+		},
+	},
+	{
+		displayName: 'Is Income',
+		name: 'is_income',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['categoryGroup'],
+				operation: ['createCategoryGroup'],
+			},
+		},
+	},
+	{
+		displayName: 'Hidden',
+		name: 'hidden',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['categoryGroup'],
+				operation: ['createCategoryGroup'],
+			},
+		},
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['categoryGroup'],
+				operation: ['updateCategoryGroup'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Is Income',
+				name: 'is_income',
+				type: 'boolean',
+				default: false,
+			},
+			{
+				displayName: 'Hidden',
+				name: 'hidden',
+				type: 'boolean',
+				default: false,
+			},
+		],
+	},
+	resourceLocatorField({
+		displayName: 'Transfer Category',
+		name: 'transferCategoryId',
+		description: 'Category to reassign this group\'s budget history to on delete, if any',
+		searchListMethod: 'searchCategories',
+		displayOptions: {
+			show: {
+				resource: ['categoryGroup'],
+				operation: ['deleteCategoryGroup'],
+			},
+		},
+	}),
+];
 
 export async function executeCategoryGroup(
 	context: IExecuteFunctions,
@@ -32,7 +150,52 @@ export async function executeCategoryGroup(
 	switch (operation) {
 		case 'getCategoryGroups':
 			return (await getCategoryGroups()) as unknown as IDataObject[];
+		case 'createCategoryGroup':
+			return handleCreateCategoryGroup(context, itemIndex);
+		case 'updateCategoryGroup':
+			return handleUpdateCategoryGroup(context, itemIndex);
+		case 'deleteCategoryGroup':
+			return handleDeleteCategoryGroup(context, itemIndex);
 		default:
 			throw new NodeOperationError(context.getNode(), `Unknown category group operation "${operation}"`);
 	}
+}
+
+function getCategoryGroupId(context: IExecuteFunctions, itemIndex: number): string {
+	return context.getNodeParameter('categoryGroupId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+}
+
+async function handleCreateCategoryGroup(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const name = context.getNodeParameter('name', itemIndex) as string;
+	const is_income = context.getNodeParameter('is_income', itemIndex) as boolean;
+	const hidden = context.getNodeParameter('hidden', itemIndex) as boolean;
+	const id = await createCategoryGroup({ name, is_income, hidden });
+	return { id, name, is_income, hidden };
+}
+
+async function handleUpdateCategoryGroup(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getCategoryGroupId(context, itemIndex);
+	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+	await updateCategoryGroup(id, fields);
+	return { success: true, id, ...fields };
+}
+
+async function handleDeleteCategoryGroup(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getCategoryGroupId(context, itemIndex);
+	const transferCategoryId = context.getNodeParameter('transferCategoryId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	await deleteCategoryGroup(id, transferCategoryId || undefined);
+	return { success: true, id };
 }

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -46,6 +46,12 @@ vi.mock("@actual-app/api", () => ({
   reopenAccount: vi.fn().mockResolvedValue(undefined),
   deleteAccount: vi.fn().mockResolvedValue(undefined),
   getAccountBalance: vi.fn().mockResolvedValue(123400),
+  createCategory: vi.fn().mockResolvedValue("cat-new"),
+  updateCategory: vi.fn().mockResolvedValue(undefined),
+  deleteCategory: vi.fn().mockResolvedValue(undefined),
+  createCategoryGroup: vi.fn().mockResolvedValue("grp-new"),
+  updateCategoryGroup: vi.fn().mockResolvedValue(undefined),
+  deleteCategoryGroup: vi.fn().mockResolvedValue(undefined),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -816,6 +822,59 @@ describe("ActualBudget", () => {
       expect(result[0]).toHaveLength(1);
       expect(result[0][0].json).toEqual({ id: "cat-1", name: "Groceries", group_id: "grp-1" });
     });
+
+    it("should call createCategory with name, group_id, is_income, and hidden", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createCategory";
+        if (name === "resource") return "category";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "Utilities";
+        if (name === "groupId") return "grp-1";
+        if (name === "is_income") return false;
+        if (name === "hidden") return false;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.createCategory).toHaveBeenCalledWith({
+        name: "Utilities",
+        group_id: "grp-1",
+        is_income: false,
+        hidden: false,
+      });
+      expect(result[0][0].json).toMatchObject({ id: "cat-new", name: "Utilities" });
+    });
+
+    it("should call updateCategory with the resolved category ID and update fields", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateCategory";
+        if (name === "resource") return "category";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "categoryId") return "cat-1";
+        if (name === "updateFields") return { name: "Groceries & Household" };
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateCategory).toHaveBeenCalledWith("cat-1", { name: "Groceries & Household" });
+    });
+
+    it("should call deleteCategory with the resolved category ID and transfer category", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deleteCategory";
+        if (name === "resource") return "category";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "categoryId") return "cat-1";
+        if (name === "transferCategoryId") return "cat-2";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.deleteCategory).toHaveBeenCalledWith("cat-1", "cat-2");
+    });
   });
 
   describe("categoryGroup resource", () => {
@@ -836,6 +895,57 @@ describe("ActualBudget", () => {
         name: "Food",
         categories: [{ id: "cat-1", name: "Groceries" }],
       });
+    });
+
+    it("should call createCategoryGroup with name, is_income, and hidden", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createCategoryGroup";
+        if (name === "resource") return "categoryGroup";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "Subscriptions";
+        if (name === "is_income") return false;
+        if (name === "hidden") return false;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.createCategoryGroup).toHaveBeenCalledWith({
+        name: "Subscriptions",
+        is_income: false,
+        hidden: false,
+      });
+      expect(result[0][0].json).toMatchObject({ id: "grp-new", name: "Subscriptions" });
+    });
+
+    it("should call updateCategoryGroup with the resolved group ID and update fields", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateCategoryGroup";
+        if (name === "resource") return "categoryGroup";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "categoryGroupId") return "grp-1";
+        if (name === "updateFields") return { hidden: true };
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateCategoryGroup).toHaveBeenCalledWith("grp-1", { hidden: true });
+    });
+
+    it("should call deleteCategoryGroup with the resolved group ID and transfer category", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deleteCategoryGroup";
+        if (name === "resource") return "categoryGroup";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "categoryGroupId") return "grp-1";
+        if (name === "transferCategoryId") return "cat-2";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.deleteCategoryGroup).toHaveBeenCalledWith("grp-1", "cat-2");
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -861,6 +861,21 @@ describe("ActualBudget", () => {
       expect(actualApi.updateCategory).toHaveBeenCalledWith("cat-1", { name: "Groceries & Household" });
     });
 
+    it("should call updateCategory with group_id and is_income together", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateCategory";
+        if (name === "resource") return "category";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "categoryId") return "cat-1";
+        if (name === "updateFields") return { group_id: "grp-2", is_income: true };
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateCategory).toHaveBeenCalledWith("cat-1", { group_id: "grp-2", is_income: true });
+    });
+
     it("should call deleteCategory with the resolved category ID and transfer category", async () => {
       executeFunctions.getNodeParameter.mockImplementation((name: string) => {
         if (name === "operation") return "deleteCategory";


### PR DESCRIPTION
## Summary
Stacked on #217.

- Adds `Create`, `Update`, `Delete` operations to the Category resource, wrapping `createCategory`/`updateCategory`/`deleteCategory`.
- Adds the same set to the Category Group resource, wrapping `createCategoryGroup`/`updateCategoryGroup`/`deleteCategoryGroup`.
- Delete operations expose an optional Transfer Category picker (both APIs accept a category to reassign budget history to).

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 57 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added create, update, and delete operations for budget categories.
  * Added create, update, and delete operations for category groups.
  * Added options to select categories and groups, set names and properties, update details, and transfer transactions when deleting.
  * Retained the ability to retrieve existing categories and category groups.

* **Tests**
  * Added coverage for category and category-group management operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->