### PR TITLE
Add Payee CRUD, merge, and common-payees lookup

### DIFF
--- a/nodes/ActualBudget/v2/actions/payee.ts
+++ b/nodes/ActualBudget/v2/actions/payee.ts
@@ -1,6 +1,15 @@
 import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
 
-import { getPayees } from '@actual-app/api';
+import {
+	createPayee,
+	deletePayee,
+	getCommonPayees,
+	getPayees,
+	mergePayees,
+	updatePayee,
+} from '@actual-app/api';
+
+import { resourceLocatorField } from '../GenericFunctions';
 
 export const payeeOperation: INodeProperties = {
 	displayName: 'Operation',
@@ -14,15 +23,118 @@ export const payeeOperation: INodeProperties = {
 	},
 	options: [
 		{
+			name: 'Create',
+			value: 'createPayee',
+			action: 'Create a payee',
+		},
+		{
+			name: 'Delete',
+			value: 'deletePayee',
+			action: 'Delete a payee',
+		},
+		{
+			name: 'Get Common',
+			value: 'getCommonPayees',
+			action: 'Get frequently used payees',
+		},
+		{
 			name: 'Get Many',
 			value: 'getPayees',
 			action: 'Get all payees',
+		},
+		{
+			name: 'Merge',
+			value: 'mergePayees',
+			action: 'Merge duplicate payees into one',
+		},
+		{
+			name: 'Update',
+			value: 'updatePayee',
+			action: 'Update a payee',
 		},
 	],
 	default: 'getPayees',
 };
 
-export const payeeFields: INodeProperties[] = [];
+export const payeeFields: INodeProperties[] = [
+	resourceLocatorField({
+		displayName: 'Payee',
+		name: 'payeeId',
+		description: 'The Payee to operate on',
+		searchListMethod: 'searchPayees',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payee'],
+				operation: ['updatePayee', 'deletePayee'],
+			},
+		},
+	}),
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payee'],
+				operation: ['createPayee'],
+			},
+		},
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['payee'],
+				operation: ['updatePayee'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+	resourceLocatorField({
+		displayName: 'Target Payee',
+		name: 'targetPayeeId',
+		description: 'The Payee that the other payees below will be merged into',
+		searchListMethod: 'searchPayees',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payee'],
+				operation: ['mergePayees'],
+			},
+		},
+	}),
+	{
+		displayName: 'Payee IDs to Merge',
+		name: 'mergeIds',
+		type: 'string',
+		default: [],
+		required: true,
+		description: 'IDs of the duplicate payees to merge into the target payee above (see the Payee "Get Many" operation to look them up)',
+		typeOptions: {
+			multipleValues: true,
+		},
+		displayOptions: {
+			show: {
+				resource: ['payee'],
+				operation: ['mergePayees'],
+			},
+		},
+	},
+];
 
 export async function executePayee(
 	context: IExecuteFunctions,
@@ -32,7 +144,61 @@ export async function executePayee(
 	switch (operation) {
 		case 'getPayees':
 			return (await getPayees()) as unknown as IDataObject[];
+		case 'getCommonPayees':
+			return (await getCommonPayees()) as unknown as IDataObject[];
+		case 'createPayee':
+			return handleCreatePayee(context, itemIndex);
+		case 'updatePayee':
+			return handleUpdatePayee(context, itemIndex);
+		case 'deletePayee':
+			return handleDeletePayee(context, itemIndex);
+		case 'mergePayees':
+			return handleMergePayees(context, itemIndex);
 		default:
 			throw new NodeOperationError(context.getNode(), `Unknown payee operation "${operation}"`);
 	}
+}
+
+function getPayeeId(context: IExecuteFunctions, itemIndex: number): string {
+	return context.getNodeParameter('payeeId', itemIndex, undefined, { extractValue: true }) as string;
+}
+
+async function handleCreatePayee(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const name = context.getNodeParameter('name', itemIndex) as string;
+	const id = await createPayee({ name });
+	return { id, name };
+}
+
+async function handleUpdatePayee(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getPayeeId(context, itemIndex);
+	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+	await updatePayee(id, fields);
+	return { success: true, id, ...fields };
+}
+
+async function handleDeletePayee(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getPayeeId(context, itemIndex);
+	await deletePayee(id);
+	return { success: true, id };
+}
+
+async function handleMergePayees(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const targetId = context.getNodeParameter('targetPayeeId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	const mergeIds = context.getNodeParameter('mergeIds', itemIndex) as string[];
+	await mergePayees(targetId, mergeIds);
+	return { success: true, targetId, mergedIds: mergeIds };
 }

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -52,6 +52,11 @@ vi.mock("@actual-app/api", () => ({
   createCategoryGroup: vi.fn().mockResolvedValue("grp-new"),
   updateCategoryGroup: vi.fn().mockResolvedValue(undefined),
   deleteCategoryGroup: vi.fn().mockResolvedValue(undefined),
+  createPayee: vi.fn().mockResolvedValue("payee-new"),
+  updatePayee: vi.fn().mockResolvedValue(undefined),
+  deletePayee: vi.fn().mockResolvedValue(undefined),
+  mergePayees: vi.fn().mockResolvedValue(undefined),
+  getCommonPayees: vi.fn().mockResolvedValue([{ id: "payee-1", name: "Landlord" }]),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -978,6 +983,80 @@ describe("ActualBudget", () => {
       expect(actualApi.getPayees).toHaveBeenCalled();
       expect(result[0]).toHaveLength(1);
       expect(result[0][0].json).toEqual({ id: "payee-1", name: "Landlord" });
+    });
+
+    it("should call getCommonPayees and return each payee as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getCommonPayees";
+        if (name === "resource") return "payee";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getCommonPayees).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+      expect(result[0][0].json).toEqual({ id: "payee-1", name: "Landlord" });
+    });
+
+    it("should call createPayee with the given name", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createPayee";
+        if (name === "resource") return "payee";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "New Payee";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.createPayee).toHaveBeenCalledWith({ name: "New Payee" });
+      expect(result[0][0].json).toEqual({ id: "payee-new", name: "New Payee" });
+    });
+
+    it("should call updatePayee with the resolved payee ID and update fields", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updatePayee";
+        if (name === "resource") return "payee";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "payeeId") return "payee-1";
+        if (name === "updateFields") return { name: "Renamed Payee" };
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updatePayee).toHaveBeenCalledWith("payee-1", { name: "Renamed Payee" });
+    });
+
+    it("should call deletePayee with the resolved payee ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deletePayee";
+        if (name === "resource") return "payee";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "payeeId") return "payee-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.deletePayee).toHaveBeenCalledWith("payee-1");
+    });
+
+    it("should call mergePayees with the target and merge IDs", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "mergePayees";
+        if (name === "resource") return "payee";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "targetPayeeId") return "payee-1";
+        if (name === "mergeIds") return ["payee-2", "payee-3"];
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.mergePayees).toHaveBeenCalledWith("payee-1", ["payee-2", "payee-3"]);
     });
   });
 


### PR DESCRIPTION
## Summary
Stacked on #218.

- Adds `Create`, `Update`, `Delete`, `Merge`, and `Get Common` operations to the Payee resource, wrapping `createPayee`/`updatePayee`/`deletePayee`/`mergePayees`/`getCommonPayees`.
- `Merge` takes a target payee (resourceLocator) and a repeatable list of raw payee IDs to fold into it (no native multi-select resourceLocator in n8n, so these are plain string entries — the Payee "Get Many" operation can be used to look IDs up).

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 62 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added expanded payee management in Actual Budget, including creating, updating, deleting, retrieving common payees, and merging payees.
  - Added operation-specific fields and lookup options for payee actions.
- **Bug Fixes**
  - Improved handling and verification of payee operation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->