### PR TITLE
Add Transaction Add/Update/Delete operations

### DIFF
--- a/nodes/ActualBudget/v2/actions/categoryGroup.ts
+++ b/nodes/ActualBudget/v2/actions/categoryGroup.ts
@@ -109,10 +109,10 @@ export const categoryGroupFields: INodeProperties[] = [
 		},
 		options: [
 			{
-				displayName: 'Name',
-				name: 'name',
-				type: 'string',
-				default: '',
+				displayName: 'Hidden',
+				name: 'hidden',
+				type: 'boolean',
+				default: false,
 			},
 			{
 				displayName: 'Is Income',
@@ -121,10 +121,10 @@ export const categoryGroupFields: INodeProperties[] = [
 				default: false,
 			},
 			{
-				displayName: 'Hidden',
-				name: 'hidden',
-				type: 'boolean',
-				default: false,
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
 			},
 		],
 	},

--- a/nodes/ActualBudget/v2/actions/transaction.ts
+++ b/nodes/ActualBudget/v2/actions/transaction.ts
@@ -5,7 +5,7 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 
-import { getTransactions, importTransactions } from '@actual-app/api';
+import { addTransactions, deleteTransaction, getTransactions, importTransactions, updateTransaction } from '@actual-app/api';
 
 import { resourceLocatorField } from '../GenericFunctions';
 
@@ -33,6 +33,16 @@ export const transactionOperation: INodeProperties = {
 	},
 	options: [
 		{
+			name: 'Add',
+			value: 'addTransactions',
+			action: 'Add a list of transactions to an account',
+		},
+		{
+			name: 'Delete',
+			value: 'deleteTransaction',
+			action: 'Delete a transaction',
+		},
+		{
 			name: 'Get Many',
 			value: 'getTransactions',
 			action: 'Get transactions from an account within a date range',
@@ -41,6 +51,11 @@ export const transactionOperation: INodeProperties = {
 			name: 'Import',
 			value: 'importTransactions',
 			action: 'Import a list of transactions into your budget',
+		},
+		{
+			name: 'Update',
+			value: 'updateTransaction',
+			action: 'Update a transaction',
 		},
 	],
 	default: 'importTransactions',
@@ -56,7 +71,7 @@ export const transactionFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['transaction'],
-				operation: ['importTransactions', 'getTransactions'],
+				operation: ['importTransactions', 'getTransactions', 'addTransactions'],
 			},
 		},
 	}),
@@ -97,9 +112,101 @@ export const transactionFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['transaction'],
-				operation: ['importTransactions'],
+				operation: ['importTransactions', 'addTransactions'],
 			},
 		},
+	},
+	{
+		displayName: 'Learn Categories',
+		name: 'learnCategories',
+		type: 'boolean',
+		default: false,
+		description: 'Whether Actual should learn payee-to-category associations from these transactions',
+		displayOptions: {
+			show: {
+				resource: ['transaction'],
+				operation: ['addTransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Run Transfers',
+		name: 'runTransfers',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to detect and link transfers between accounts',
+		displayOptions: {
+			show: {
+				resource: ['transaction'],
+				operation: ['addTransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Transaction ID',
+		name: 'transactionId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the transaction (see the Transaction "Get Many" operation to look it up)',
+		displayOptions: {
+			show: {
+				resource: ['transaction'],
+				operation: ['updateTransaction', 'deleteTransaction'],
+			},
+		},
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['transaction'],
+				operation: ['updateTransaction'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Amount',
+				name: 'amount',
+				type: 'number',
+				default: 0,
+			},
+			{
+				displayName: 'Category ID',
+				name: 'category',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Cleared',
+				name: 'cleared',
+				type: 'boolean',
+				default: false,
+			},
+			{
+				displayName: 'Date',
+				name: 'date',
+				type: 'string',
+				default: '',
+				description: 'Date in YYYY-MM-DD format',
+			},
+			{
+				displayName: 'Notes',
+				name: 'notes',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Payee ID',
+				name: 'payee',
+				type: 'string',
+				default: '',
+			},
+		],
 	},
 ];
 
@@ -113,40 +220,22 @@ export async function executeTransaction(
 			return handleGetTransactions(context, itemIndex);
 		case 'importTransactions':
 			return handleImportTransactions(context, itemIndex);
+		case 'addTransactions':
+			return handleAddTransactions(context, itemIndex);
+		case 'updateTransaction':
+			return handleUpdateTransaction(context, itemIndex);
+		case 'deleteTransaction':
+			return handleDeleteTransaction(context, itemIndex);
 		default:
 			throw new NodeOperationError(context.getNode(), `Unknown transaction operation "${operation}"`);
 	}
 }
 
-async function handleGetTransactions(
-	context: IExecuteFunctions,
-	itemIndex: number,
-): Promise<IDataObject[]> {
-	const accountId = context.getNodeParameter('accountId', itemIndex, undefined, {
-		extractValue: true,
-	}) as string;
-	const startDate = context.getNodeParameter('startDate', itemIndex) as string;
-	const endDate = context.getNodeParameter('endDate', itemIndex) as string;
-	const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-	if (!datePattern.test(startDate)) {
-		throw new NodeOperationError(context.getNode(), `"startDate" must be in YYYY-MM-DD format, got "${startDate}"`);
-	}
-	if (!datePattern.test(endDate)) {
-		throw new NodeOperationError(context.getNode(), `"endDate" must be in YYYY-MM-DD format, got "${endDate}"`);
-	}
-	if (startDate > endDate) {
-		throw new NodeOperationError(context.getNode(), `"startDate" (${startDate}) must be on or before "endDate" (${endDate})`);
-	}
-	return (await getTransactions(accountId, startDate, endDate)) as unknown as IDataObject[];
+function getAccountId(context: IExecuteFunctions, itemIndex: number): string {
+	return context.getNodeParameter('accountId', itemIndex, undefined, { extractValue: true }) as string;
 }
 
-async function handleImportTransactions(
-	context: IExecuteFunctions,
-	itemIndex: number,
-): Promise<IDataObject> {
-	const accountId = context.getNodeParameter('accountId', itemIndex, undefined, {
-		extractValue: true,
-	}) as string;
+function parseTransactionsInput(context: IExecuteFunctions, itemIndex: number): ActualTransaction[] {
 	const raw = context.getNodeParameter('transactions', itemIndex);
 	let parsed: unknown;
 	if (typeof raw === 'string') {
@@ -169,9 +258,67 @@ async function handleImportTransactions(
 			);
 		}
 	}
-	const transactions = parsed as ActualTransaction[];
+	return parsed as ActualTransaction[];
+}
 
+async function handleGetTransactions(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject[]> {
+	const accountId = getAccountId(context, itemIndex);
+	const startDate = context.getNodeParameter('startDate', itemIndex) as string;
+	const endDate = context.getNodeParameter('endDate', itemIndex) as string;
+	const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+	if (!datePattern.test(startDate)) {
+		throw new NodeOperationError(context.getNode(), `"startDate" must be in YYYY-MM-DD format, got "${startDate}"`);
+	}
+	if (!datePattern.test(endDate)) {
+		throw new NodeOperationError(context.getNode(), `"endDate" must be in YYYY-MM-DD format, got "${endDate}"`);
+	}
+	if (startDate > endDate) {
+		throw new NodeOperationError(context.getNode(), `"startDate" (${startDate}) must be on or before "endDate" (${endDate})`);
+	}
+	return (await getTransactions(accountId, startDate, endDate)) as unknown as IDataObject[];
+}
+
+async function handleImportTransactions(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const accountId = getAccountId(context, itemIndex);
+	const transactions = parseTransactionsInput(context, itemIndex);
 	return (await importTransactions(accountId, transactions)) as unknown as IDataObject;
+}
+
+async function handleAddTransactions(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const accountId = getAccountId(context, itemIndex);
+	const transactions = parseTransactionsInput(context, itemIndex);
+	const learnCategories = context.getNodeParameter('learnCategories', itemIndex) as boolean;
+	const runTransfers = context.getNodeParameter('runTransfers', itemIndex) as boolean;
+	const result = await addTransactions(accountId, transactions, { learnCategories, runTransfers });
+	return { result };
+}
+
+async function handleUpdateTransaction(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = context.getNodeParameter('transactionId', itemIndex) as string;
+	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+	const result = await updateTransaction(id, fields);
+	return { success: true, id, result } as unknown as IDataObject;
+}
+
+async function handleDeleteTransaction(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = context.getNodeParameter('transactionId', itemIndex) as string;
+	await deleteTransaction(id);
+	return { success: true, id };
 }
 
 function isActualTransaction(value: unknown): value is ActualTransaction {

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -57,6 +57,9 @@ vi.mock("@actual-app/api", () => ({
   deletePayee: vi.fn().mockResolvedValue(undefined),
   mergePayees: vi.fn().mockResolvedValue(undefined),
   getCommonPayees: vi.fn().mockResolvedValue([{ id: "payee-1", name: "Landlord" }]),
+  addTransactions: vi.fn().mockResolvedValue("ok"),
+  updateTransaction: vi.fn().mockResolvedValue([{ id: "tx-001" }]),
+  deleteTransaction: vi.fn().mockResolvedValue([{ id: "tx-001" }]),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -490,6 +493,63 @@ describe("ActualBudget", () => {
 
       expect(result).toBeDefined();
       expect(actualApi.getTransactions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("addTransactions operation", () => {
+    it("should call addTransactions with accountId, transactions, and options", async () => {
+      const transactions = [{ date: "2024-01-15", amount: -1000 }];
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "addTransactions";
+        if (name === "resource") return "transaction";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "account-abc";
+        if (name === "transactions") return transactions;
+        if (name === "learnCategories") return true;
+        if (name === "runTransfers") return false;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.addTransactions).toHaveBeenCalledWith("account-abc", transactions, {
+        learnCategories: true,
+        runTransfers: false,
+      });
+      expect(result[0][0].json).toEqual({ result: "ok" });
+    });
+  });
+
+  describe("updateTransaction operation", () => {
+    it("should call updateTransaction with the transaction ID and update fields", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateTransaction";
+        if (name === "resource") return "transaction";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "transactionId") return "tx-001";
+        if (name === "updateFields") return { notes: "Updated" };
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateTransaction).toHaveBeenCalledWith("tx-001", { notes: "Updated" });
+    });
+  });
+
+  describe("deleteTransaction operation", () => {
+    it("should call deleteTransaction with the transaction ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deleteTransaction";
+        if (name === "resource") return "transaction";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "transactionId") return "tx-001";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.deleteTransaction).toHaveBeenCalledWith("tx-001");
     });
   });
 


### PR DESCRIPTION
## Summary
Stacked on #219.

- Adds `Add`, `Update`, `Delete` operations to the Transaction resource, wrapping `addTransactions`/`updateTransaction`/`deleteTransaction`.
- `Add` reuses the existing Account/Transactions fields (shared with Import) plus new Learn Categories/Run Transfers toggles.
- `Update`/`Delete` take a raw Transaction ID field rather than a resourceLocator — there's no practical way to list/search transactions the way accounts/categories/payees can (could be thousands per account), so the ID is expected to come from a prior "Get Many" step.
- Also fixes collection option ordering in `category.ts`/`categoryGroup.ts` flagged by the `node-param-collection-type-unsorted-items` lint rule, noticed while adding `transaction.ts`'s own Update Fields collection.

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 65 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating, updating, and deleting transactions.
  * Added options for transaction IDs, category learning, transfer detection, and selected fields.

* **Bug Fixes**
  * Improved transaction input handling and account selection for transaction operations.

* **Tests**
  * Added coverage for transaction creation, updates, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->