### PR TITLE
Add Rule and Schedule resources

### DIFF
--- a/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
+++ b/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
@@ -25,6 +25,8 @@ import {
 	executeCategoryGroup,
 } from './actions/categoryGroup';
 import { payeeOperation, payeeFields, executePayee } from './actions/payee';
+import { ruleOperation, ruleFields, executeRule } from './actions/rule';
+import { scheduleOperation, scheduleFields, executeSchedule } from './actions/schedule';
 import { transactionOperation, transactionFields, executeTransaction } from './actions/transaction';
 
 import { searchAccounts, searchCategories, searchCategoryGroups, searchPayees } from './methods/listSearch';
@@ -86,6 +88,14 @@ export class ActualBudgetV2 implements INodeType {
 						value: 'payee',
 					},
 					{
+						name: 'Rule',
+						value: 'rule',
+					},
+					{
+						name: 'Schedule',
+						value: 'schedule',
+					},
+					{
 						name: 'Transaction',
 						value: 'transaction',
 					},
@@ -98,12 +108,16 @@ export class ActualBudgetV2 implements INodeType {
 			categoryOperation,
 			categoryGroupOperation,
 			payeeOperation,
+			ruleOperation,
+			scheduleOperation,
 			transactionOperation,
 			...accountFields,
 			...budgetFields,
 			...categoryFields,
 			...categoryGroupFields,
 			...payeeFields,
+			...ruleFields,
+			...scheduleFields,
 			...transactionFields,
 		],
 		usableAsTool: undefined,
@@ -199,6 +213,10 @@ async function dispatch(
 			return executeCategoryGroup(context, itemIndex, operation);
 		case 'payee':
 			return executePayee(context, itemIndex, operation);
+		case 'rule':
+			return executeRule(context, itemIndex, operation);
+		case 'schedule':
+			return executeSchedule(context, itemIndex, operation);
 		case 'transaction':
 			return executeTransaction(context, itemIndex, operation);
 		default:

--- a/nodes/ActualBudget/v2/actions/rule.ts
+++ b/nodes/ActualBudget/v2/actions/rule.ts
@@ -1,0 +1,167 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { createRule, deleteRule, getPayeeRules, getRules, updateRule } from '@actual-app/api';
+
+import { resourceLocatorField } from '../GenericFunctions';
+
+export const ruleOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['rule'],
+		},
+	},
+	options: [
+		{
+			name: 'Create',
+			value: 'createRule',
+			action: 'Create a rule',
+		},
+		{
+			name: 'Delete',
+			value: 'deleteRule',
+			action: 'Delete a rule',
+		},
+		{
+			name: 'Get for Payee',
+			value: 'getPayeeRules',
+			action: 'Get rules for a specific payee',
+		},
+		{
+			name: 'Get Many',
+			value: 'getRules',
+			action: 'Get all rules',
+		},
+		{
+			name: 'Update',
+			value: 'updateRule',
+			action: 'Update a rule',
+		},
+	],
+	default: 'getRules',
+};
+
+const ruleJsonField = (name: string, displayOptions: string[]): INodeProperties => ({
+	displayName: 'Rule',
+	name,
+	type: 'json',
+	default: '{\n  "stage": null,\n  "conditionsOp": "and",\n  "conditions": [],\n  "actions": []\n}',
+	required: true,
+	description:
+		'The rule body, matching the Actual rule schema: { stage, conditionsOp, conditions, actions }. See https://actualbudget.org/docs/api/reference/#rule for the condition/action shapes.',
+	displayOptions: {
+		show: {
+			resource: ['rule'],
+			operation: displayOptions,
+		},
+	},
+});
+
+export const ruleFields: INodeProperties[] = [
+	resourceLocatorField({
+		displayName: 'Payee',
+		name: 'payeeId',
+		description: 'The Payee to get rules for',
+		searchListMethod: 'searchPayees',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['rule'],
+				operation: ['getPayeeRules'],
+			},
+		},
+	}),
+	{
+		displayName: 'Rule ID',
+		name: 'ruleId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the rule (see the Rule "Get Many" operation to look it up)',
+		displayOptions: {
+			show: {
+				resource: ['rule'],
+				operation: ['updateRule', 'deleteRule'],
+			},
+		},
+	},
+	ruleJsonField('rule', ['createRule', 'updateRule']),
+];
+
+export async function executeRule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getRules':
+			return (await getRules()) as unknown as IDataObject[];
+		case 'getPayeeRules':
+			return handleGetPayeeRules(context, itemIndex);
+		case 'createRule':
+			return handleCreateRule(context, itemIndex);
+		case 'updateRule':
+			return handleUpdateRule(context, itemIndex);
+		case 'deleteRule':
+			return handleDeleteRule(context, itemIndex);
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown rule operation "${operation}"`);
+	}
+}
+
+function parseRuleJson(context: IExecuteFunctions, itemIndex: number): IDataObject {
+	const raw = context.getNodeParameter('rule', itemIndex);
+	let parsed: unknown;
+	if (typeof raw === 'string') {
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			throw new NodeOperationError(context.getNode(), 'Rule field contains invalid JSON');
+		}
+	} else {
+		parsed = raw;
+	}
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		throw new NodeOperationError(context.getNode(), '"rule" must be a JSON object');
+	}
+	return parsed as IDataObject;
+}
+
+async function handleGetPayeeRules(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject[]> {
+	const payeeId = context.getNodeParameter('payeeId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	return (await getPayeeRules(payeeId)) as unknown as IDataObject[];
+}
+
+async function handleCreateRule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const rule = parseRuleJson(context, itemIndex);
+	return (await createRule(rule as never)) as unknown as IDataObject;
+}
+
+async function handleUpdateRule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = context.getNodeParameter('ruleId', itemIndex) as string;
+	const rule = parseRuleJson(context, itemIndex);
+	return (await updateRule({ id, ...rule } as never)) as unknown as IDataObject;
+}
+
+async function handleDeleteRule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = context.getNodeParameter('ruleId', itemIndex) as string;
+	const success = await deleteRule(id);
+	return { success, id };
+}

--- a/nodes/ActualBudget/v2/actions/rule.ts
+++ b/nodes/ActualBudget/v2/actions/rule.ts
@@ -154,7 +154,7 @@ async function handleUpdateRule(
 ): Promise<IDataObject> {
 	const id = context.getNodeParameter('ruleId', itemIndex) as string;
 	const rule = parseRuleJson(context, itemIndex);
-	return (await updateRule({ id, ...rule } as never)) as unknown as IDataObject;
+	return (await updateRule({ ...rule, id } as never)) as unknown as IDataObject;
 }
 
 async function handleDeleteRule(

--- a/nodes/ActualBudget/v2/actions/schedule.ts
+++ b/nodes/ActualBudget/v2/actions/schedule.ts
@@ -98,19 +98,6 @@ export const scheduleFields: INodeProperties[] = [
 		},
 	}),
 	{
-		displayName: 'Amount',
-		name: 'amount',
-		type: 'number',
-		default: 0,
-		description: 'Amount in cents',
-		displayOptions: {
-			show: {
-				resource: ['schedule'],
-				operation: ['createSchedule'],
-			},
-		},
-	},
-	{
 		displayName: 'Amount Operator',
 		name: 'amountOp',
 		type: 'options',
@@ -124,10 +111,53 @@ export const scheduleFields: INodeProperties[] = [
 		},
 	},
 	{
+		displayName: 'Amount',
+		name: 'amount',
+		type: 'number',
+		default: 0,
+		description: 'Amount in cents',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+				amountOp: ['is', 'isapprox'],
+			},
+		},
+	},
+	{
+		displayName: 'Amount Lower',
+		name: 'amountLower',
+		type: 'number',
+		default: 0,
+		description: 'Lower bound of the amount range, in cents',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+				amountOp: ['isbetween'],
+			},
+		},
+	},
+	{
+		displayName: 'Amount Upper',
+		name: 'amountUpper',
+		type: 'number',
+		default: 0,
+		description: 'Upper bound of the amount range, in cents',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+				amountOp: ['isbetween'],
+			},
+		},
+	},
+	{
 		displayName: 'Date',
 		name: 'date',
 		type: 'json',
 		default: '""',
+		required: true,
 		description:
 			'A date string (YYYY-MM-DD) for a one-off schedule, or a recurring-date config object per the Actual API docs',
 		displayOptions: {
@@ -168,6 +198,23 @@ export const scheduleFields: INodeProperties[] = [
 				name: 'amount',
 				type: 'number',
 				default: 0,
+				displayOptions: {
+					show: {
+						amountOp: ['is', 'isapprox'],
+					},
+				},
+			},
+			{
+				displayName: 'Amount Lower',
+				name: 'amountLower',
+				type: 'number',
+				default: 0,
+				description: 'Lower bound of the amount range, in cents',
+				displayOptions: {
+					show: {
+						amountOp: ['isbetween'],
+					},
+				},
 			},
 			{
 				displayName: 'Amount Operator',
@@ -175,6 +222,18 @@ export const scheduleFields: INodeProperties[] = [
 				type: 'options',
 				options: amountOpOptions,
 				default: 'is',
+			},
+			{
+				displayName: 'Amount Upper',
+				name: 'amountUpper',
+				type: 'number',
+				default: 0,
+				description: 'Upper bound of the amount range, in cents',
+				displayOptions: {
+					show: {
+						amountOp: ['isbetween'],
+					},
+				},
 			},
 			{
 				displayName: 'Date',
@@ -239,6 +298,19 @@ function parseDateField(raw: unknown): unknown {
 	}
 }
 
+function isEmptyDate(date: unknown): boolean {
+	return date === null || date === undefined || date === '';
+}
+
+function resolveAmount(
+	amountOp: string,
+	amount: number,
+	amountLower: number,
+	amountUpper: number,
+): number | { num1: number; num2: number } {
+	return amountOp === 'isbetween' ? { num1: amountLower, num2: amountUpper } : amount;
+}
+
 async function handleCreateSchedule(
 	context: IExecuteFunctions,
 	itemIndex: number,
@@ -250,9 +322,17 @@ async function handleCreateSchedule(
 	const payeeId = context.getNodeParameter('payeeId', itemIndex, undefined, {
 		extractValue: true,
 	}) as string;
-	const amount = context.getNodeParameter('amount', itemIndex) as number;
 	const amountOp = context.getNodeParameter('amountOp', itemIndex) as 'is' | 'isapprox' | 'isbetween';
+	const amount = resolveAmount(
+		amountOp,
+		context.getNodeParameter('amount', itemIndex) as number,
+		context.getNodeParameter('amountLower', itemIndex) as number,
+		context.getNodeParameter('amountUpper', itemIndex) as number,
+	);
 	const date = parseDateField(context.getNodeParameter('date', itemIndex));
+	if (isEmptyDate(date)) {
+		throw new NodeOperationError(context.getNode(), '"date" must not be empty');
+	}
 	const posts_transaction = context.getNodeParameter('posts_transaction', itemIndex) as boolean;
 
 	const id = await createSchedule({
@@ -273,8 +353,30 @@ async function handleUpdateSchedule(
 ): Promise<IDataObject> {
 	const id = context.getNodeParameter('scheduleId', itemIndex) as string;
 	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+
+	// amountLower/amountUpper are UI-only helper params for the "Is Between" range value,
+	// not real APIScheduleEntity fields - fold them into "amount" and strip them before
+	// sending, same shape as createSchedule's resolveAmount().
+	const amountLower = fields.amountLower as number | undefined;
+	const amountUpper = fields.amountUpper as number | undefined;
+	delete fields.amountLower;
+	delete fields.amountUpper;
+	if (fields.amountOp === 'isbetween') {
+		if (typeof amountLower !== 'number' || typeof amountUpper !== 'number') {
+			throw new NodeOperationError(
+				context.getNode(),
+				'When "Amount Operator" is "Is Between", both "Amount Lower" and "Amount Upper" must be set',
+			);
+		}
+		fields.amount = { num1: amountLower, num2: amountUpper };
+	}
+
 	if (typeof fields.date !== 'undefined') {
-		fields.date = parseDateField(fields.date) as IDataObject['date'];
+		const parsedDate = parseDateField(fields.date);
+		if (isEmptyDate(parsedDate)) {
+			throw new NodeOperationError(context.getNode(), '"date" must not be empty');
+		}
+		fields.date = parsedDate as IDataObject['date'];
 	}
 	const resetNextDate = context.getNodeParameter('resetNextDate', itemIndex) as boolean;
 	await updateSchedule(id, fields, resetNextDate);

--- a/nodes/ActualBudget/v2/actions/schedule.ts
+++ b/nodes/ActualBudget/v2/actions/schedule.ts
@@ -1,0 +1,291 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { createSchedule, deleteSchedule, getSchedules, updateSchedule } from '@actual-app/api';
+
+import { resourceLocatorField } from '../GenericFunctions';
+
+export const scheduleOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['schedule'],
+		},
+	},
+	options: [
+		{
+			name: 'Create',
+			value: 'createSchedule',
+			action: 'Create a schedule',
+		},
+		{
+			name: 'Delete',
+			value: 'deleteSchedule',
+			action: 'Delete a schedule',
+		},
+		{
+			name: 'Get Many',
+			value: 'getSchedules',
+			action: 'Get all schedules',
+		},
+		{
+			name: 'Update',
+			value: 'updateSchedule',
+			action: 'Update a schedule',
+		},
+	],
+	default: 'getSchedules',
+};
+
+const amountOpOptions = [
+	{ name: 'Is', value: 'is' },
+	{ name: 'Is Approximately', value: 'isapprox' },
+	{ name: 'Is Between', value: 'isbetween' },
+];
+
+export const scheduleFields: INodeProperties[] = [
+	{
+		displayName: 'Schedule ID',
+		name: 'scheduleId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the schedule (see the Schedule "Get Many" operation to look it up)',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['updateSchedule', 'deleteSchedule'],
+			},
+		},
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+			},
+		},
+	},
+	resourceLocatorField({
+		displayName: 'Account',
+		name: 'accountId',
+		description: 'The Account this schedule applies to',
+		searchListMethod: 'searchAccounts',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+			},
+		},
+	}),
+	resourceLocatorField({
+		displayName: 'Payee',
+		name: 'payeeId',
+		description: 'The Payee this schedule applies to',
+		searchListMethod: 'searchPayees',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+			},
+		},
+	}),
+	{
+		displayName: 'Amount',
+		name: 'amount',
+		type: 'number',
+		default: 0,
+		description: 'Amount in cents',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+			},
+		},
+	},
+	{
+		displayName: 'Amount Operator',
+		name: 'amountOp',
+		type: 'options',
+		options: amountOpOptions,
+		default: 'is',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+			},
+		},
+	},
+	{
+		displayName: 'Date',
+		name: 'date',
+		type: 'json',
+		default: '""',
+		description:
+			'A date string (YYYY-MM-DD) for a one-off schedule, or a recurring-date config object per the Actual API docs',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+			},
+		},
+	},
+	{
+		displayName: 'Posts Transaction',
+		name: 'posts_transaction',
+		type: 'boolean',
+		default: false,
+		description: 'Whether Actual should automatically post a transaction when this schedule is due',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['createSchedule'],
+			},
+		},
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['updateSchedule'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Amount',
+				name: 'amount',
+				type: 'number',
+				default: 0,
+			},
+			{
+				displayName: 'Amount Operator',
+				name: 'amountOp',
+				type: 'options',
+				options: amountOpOptions,
+				default: 'is',
+			},
+			{
+				displayName: 'Date',
+				name: 'date',
+				type: 'json',
+				default: '""',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Posts Transaction',
+				name: 'posts_transaction',
+				type: 'boolean',
+				default: false,
+			},
+		],
+	},
+	{
+		displayName: 'Reset Next Date',
+		name: 'resetNextDate',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to recompute the next occurrence date from today rather than the schedule\'s prior state',
+		displayOptions: {
+			show: {
+				resource: ['schedule'],
+				operation: ['updateSchedule'],
+			},
+		},
+	},
+];
+
+export async function executeSchedule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getSchedules':
+			return (await getSchedules()) as unknown as IDataObject[];
+		case 'createSchedule':
+			return handleCreateSchedule(context, itemIndex);
+		case 'updateSchedule':
+			return handleUpdateSchedule(context, itemIndex);
+		case 'deleteSchedule':
+			return handleDeleteSchedule(context, itemIndex);
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown schedule operation "${operation}"`);
+	}
+}
+
+function parseDateField(raw: unknown): unknown {
+	if (typeof raw !== 'string') return raw;
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return raw;
+	}
+}
+
+async function handleCreateSchedule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const name = context.getNodeParameter('name', itemIndex) as string;
+	const accountId = context.getNodeParameter('accountId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	const payeeId = context.getNodeParameter('payeeId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	const amount = context.getNodeParameter('amount', itemIndex) as number;
+	const amountOp = context.getNodeParameter('amountOp', itemIndex) as 'is' | 'isapprox' | 'isbetween';
+	const date = parseDateField(context.getNodeParameter('date', itemIndex));
+	const posts_transaction = context.getNodeParameter('posts_transaction', itemIndex) as boolean;
+
+	const id = await createSchedule({
+		name,
+		account: accountId,
+		payee: payeeId || undefined,
+		amount,
+		amountOp,
+		date,
+		posts_transaction,
+	} as never);
+	return { id, name };
+}
+
+async function handleUpdateSchedule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = context.getNodeParameter('scheduleId', itemIndex) as string;
+	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+	if (typeof fields.date !== 'undefined') {
+		fields.date = parseDateField(fields.date) as IDataObject['date'];
+	}
+	const resetNextDate = context.getNodeParameter('resetNextDate', itemIndex) as boolean;
+	await updateSchedule(id, fields, resetNextDate);
+	return { success: true, id, ...fields };
+}
+
+async function handleDeleteSchedule(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = context.getNodeParameter('scheduleId', itemIndex) as string;
+	await deleteSchedule(id);
+	return { success: true, id };
+}

--- a/nodes/ActualBudget/v2/actions/schedule.ts
+++ b/nodes/ActualBudget/v2/actions/schedule.ts
@@ -303,12 +303,17 @@ function isEmptyDate(date: unknown): boolean {
 }
 
 function resolveAmount(
+	context: IExecuteFunctions,
 	amountOp: string,
 	amount: number,
 	amountLower: number,
 	amountUpper: number,
 ): number | { num1: number; num2: number } {
-	return amountOp === 'isbetween' ? { num1: amountLower, num2: amountUpper } : amount;
+	if (amountOp !== 'isbetween') return amount;
+	if (amountLower > amountUpper) {
+		throw new NodeOperationError(context.getNode(), '"Amount Lower" must be less than or equal to "Amount Upper"');
+	}
+	return { num1: amountLower, num2: amountUpper };
 }
 
 async function handleCreateSchedule(
@@ -324,6 +329,7 @@ async function handleCreateSchedule(
 	}) as string;
 	const amountOp = context.getNodeParameter('amountOp', itemIndex) as 'is' | 'isapprox' | 'isbetween';
 	const amount = resolveAmount(
+		context,
 		amountOp,
 		context.getNodeParameter('amount', itemIndex) as number,
 		context.getNodeParameter('amountLower', itemIndex) as number,
@@ -367,6 +373,9 @@ async function handleUpdateSchedule(
 				context.getNode(),
 				'When "Amount Operator" is "Is Between", both "Amount Lower" and "Amount Upper" must be set',
 			);
+		}
+		if (amountLower > amountUpper) {
+			throw new NodeOperationError(context.getNode(), '"Amount Lower" must be less than or equal to "Amount Upper"');
 		}
 		fields.amount = { num1: amountLower, num2: amountUpper };
 	}

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -60,6 +60,15 @@ vi.mock("@actual-app/api", () => ({
   addTransactions: vi.fn().mockResolvedValue("ok"),
   updateTransaction: vi.fn().mockResolvedValue([{ id: "tx-001" }]),
   deleteTransaction: vi.fn().mockResolvedValue([{ id: "tx-001" }]),
+  getRules: vi.fn().mockResolvedValue([{ id: "rule-1", stage: null, conditionsOp: "and", conditions: [], actions: [] }]),
+  getPayeeRules: vi.fn().mockResolvedValue([{ id: "rule-1", stage: null, conditionsOp: "and", conditions: [], actions: [] }]),
+  createRule: vi.fn().mockResolvedValue({ id: "rule-new", stage: null, conditionsOp: "and", conditions: [], actions: [] }),
+  updateRule: vi.fn().mockResolvedValue({ id: "rule-1", stage: null, conditionsOp: "and", conditions: [], actions: [] }),
+  deleteRule: vi.fn().mockResolvedValue(true),
+  getSchedules: vi.fn().mockResolvedValue([{ id: "sched-1", name: "Rent" }]),
+  createSchedule: vi.fn().mockResolvedValue("sched-new"),
+  updateSchedule: vi.fn().mockResolvedValue("sched-1"),
+  deleteSchedule: vi.fn().mockResolvedValue(undefined),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -1117,6 +1126,168 @@ describe("ActualBudget", () => {
       await node.execute.call(executeFunctions);
 
       expect(actualApi.mergePayees).toHaveBeenCalledWith("payee-1", ["payee-2", "payee-3"]);
+    });
+  });
+
+  describe("rule resource", () => {
+    it("should call getRules and return each rule as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getRules";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getRules).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+    });
+
+    it("should call getPayeeRules with the resolved payee ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getPayeeRules";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "payeeId") return "payee-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.getPayeeRules).toHaveBeenCalledWith("payee-1");
+    });
+
+    it("should call createRule with the parsed rule JSON", async () => {
+      const rule = { stage: null, conditionsOp: "and", conditions: [], actions: [] };
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createRule";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "rule") return JSON.stringify(rule);
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.createRule).toHaveBeenCalledWith(rule);
+    });
+
+    it("should throw on invalid rule JSON", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createRule";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "rule") return "not json";
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/invalid JSON/);
+    });
+
+    it("should call updateRule with the id merged into the parsed rule JSON", async () => {
+      const rule = { stage: null, conditionsOp: "and", conditions: [], actions: [] };
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateRule";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "ruleId") return "rule-1";
+        if (name === "rule") return JSON.stringify(rule);
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateRule).toHaveBeenCalledWith({ id: "rule-1", ...rule });
+    });
+
+    it("should call deleteRule with the rule ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deleteRule";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "ruleId") return "rule-1";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.deleteRule).toHaveBeenCalledWith("rule-1");
+      expect(result[0][0].json).toEqual({ success: true, id: "rule-1" });
+    });
+  });
+
+  describe("schedule resource", () => {
+    it("should call getSchedules and return each schedule as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getSchedules";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getSchedules).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+    });
+
+    it("should call createSchedule with the resolved account/payee and other fields", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "Rent";
+        if (name === "accountId") return "acc-1";
+        if (name === "payeeId") return "payee-1";
+        if (name === "amount") return -150000;
+        if (name === "amountOp") return "is";
+        if (name === "date") return '"2024-04-01"';
+        if (name === "posts_transaction") return true;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.createSchedule).toHaveBeenCalledWith({
+        name: "Rent",
+        account: "acc-1",
+        payee: "payee-1",
+        amount: -150000,
+        amountOp: "is",
+        date: "2024-04-01",
+        posts_transaction: true,
+      });
+    });
+
+    it("should call updateSchedule with the resolved schedule ID, fields, and resetNextDate", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "scheduleId") return "sched-1";
+        if (name === "updateFields") return { amount: -160000 };
+        if (name === "resetNextDate") return true;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateSchedule).toHaveBeenCalledWith("sched-1", { amount: -160000 }, true);
+    });
+
+    it("should call deleteSchedule with the schedule ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deleteSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "scheduleId") return "sched-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.deleteSchedule).toHaveBeenCalledWith("sched-1");
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -1305,6 +1305,26 @@ describe("ActualBudget", () => {
       });
     });
 
+    it("should throw when creating with Is Between and Amount Lower exceeds Amount Upper", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "Utilities";
+        if (name === "accountId") return "acc-1";
+        if (name === "payeeId") return "payee-1";
+        if (name === "amountOp") return "isbetween";
+        if (name === "amountLower") return -100000;
+        if (name === "amountUpper") return -200000;
+        if (name === "date") return '"2024-04-01"';
+        if (name === "posts_transaction") return true;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/Amount Lower.*Amount Upper/);
+      expect(actualApi.createSchedule).not.toHaveBeenCalled();
+    });
+
     it("should throw when creating a schedule with an empty date", async () => {
       executeFunctions.getNodeParameter.mockImplementation((name: string) => {
         if (name === "operation") return "createSchedule";
@@ -1367,6 +1387,21 @@ describe("ActualBudget", () => {
         if (name === "budgetId") return "test-budget-id";
         if (name === "scheduleId") return "sched-1";
         if (name === "updateFields") return { amountOp: "isbetween" };
+        if (name === "resetNextDate") return false;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/Amount Lower.*Amount Upper/);
+      expect(actualApi.updateSchedule).not.toHaveBeenCalled();
+    });
+
+    it("should throw when updating with Is Between and Amount Lower exceeds Amount Upper", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "scheduleId") return "sched-1";
+        if (name === "updateFields") return { amountOp: "isbetween", amountLower: -100000, amountUpper: -200000 };
         if (name === "resetNextDate") return false;
         return undefined;
       });

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -1201,6 +1201,22 @@ describe("ActualBudget", () => {
       expect(actualApi.updateRule).toHaveBeenCalledWith({ id: "rule-1", ...rule });
     });
 
+    it("should let the selected Rule ID win over a conflicting id in the rule JSON body", async () => {
+      const rule = { id: "rule-from-json-should-be-ignored", stage: null, conditionsOp: "and", conditions: [], actions: [] };
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateRule";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "ruleId") return "rule-1";
+        if (name === "rule") return JSON.stringify(rule);
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateRule).toHaveBeenCalledWith({ ...rule, id: "rule-1" });
+    });
+
     it("should call deleteRule with the rule ID", async () => {
       executeFunctions.getNodeParameter.mockImplementation((name: string) => {
         if (name === "operation") return "deleteRule";
@@ -1260,6 +1276,54 @@ describe("ActualBudget", () => {
       });
     });
 
+    it("should call createSchedule with a {num1, num2} amount range when Amount Operator is Is Between", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "Utilities";
+        if (name === "accountId") return "acc-1";
+        if (name === "payeeId") return "payee-1";
+        if (name === "amountOp") return "isbetween";
+        if (name === "amountLower") return -200000;
+        if (name === "amountUpper") return -100000;
+        if (name === "date") return '"2024-04-01"';
+        if (name === "posts_transaction") return true;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.createSchedule).toHaveBeenCalledWith({
+        name: "Utilities",
+        account: "acc-1",
+        payee: "payee-1",
+        amount: { num1: -200000, num2: -100000 },
+        amountOp: "isbetween",
+        date: "2024-04-01",
+        posts_transaction: true,
+      });
+    });
+
+    it("should throw when creating a schedule with an empty date", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "name") return "Rent";
+        if (name === "accountId") return "acc-1";
+        if (name === "payeeId") return "payee-1";
+        if (name === "amount") return -150000;
+        if (name === "amountOp") return "is";
+        if (name === "date") return '""';
+        if (name === "posts_transaction") return true;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/"date"/);
+      expect(actualApi.createSchedule).not.toHaveBeenCalled();
+    });
+
     it("should call updateSchedule with the resolved schedule ID, fields, and resetNextDate", async () => {
       executeFunctions.getNodeParameter.mockImplementation((name: string) => {
         if (name === "operation") return "updateSchedule";
@@ -1274,6 +1338,56 @@ describe("ActualBudget", () => {
       await node.execute.call(executeFunctions);
 
       expect(actualApi.updateSchedule).toHaveBeenCalledWith("sched-1", { amount: -160000 }, true);
+    });
+
+    it("should call updateSchedule with a {num1, num2} amount range when Amount Operator is Is Between", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "scheduleId") return "sched-1";
+        if (name === "updateFields") return { amountOp: "isbetween", amountLower: -200000, amountUpper: -100000 };
+        if (name === "resetNextDate") return false;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateSchedule).toHaveBeenCalledWith(
+        "sched-1",
+        { amountOp: "isbetween", amount: { num1: -200000, num2: -100000 } },
+        false,
+      );
+    });
+
+    it("should throw when updating with Is Between but Amount Lower/Upper are missing", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "scheduleId") return "sched-1";
+        if (name === "updateFields") return { amountOp: "isbetween" };
+        if (name === "resetNextDate") return false;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/Amount Lower.*Amount Upper/);
+      expect(actualApi.updateSchedule).not.toHaveBeenCalled();
+    });
+
+    it("should throw when updating a schedule with an empty date", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateSchedule";
+        if (name === "resource") return "schedule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "scheduleId") return "sched-1";
+        if (name === "updateFields") return { date: '""' };
+        if (name === "resetNextDate") return false;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/"date"/);
+      expect(actualApi.updateSchedule).not.toHaveBeenCalled();
     });
 
     it("should call deleteSchedule with the schedule ID", async () => {


### PR DESCRIPTION
## Summary
Stacked on #220.

- Adds `Get Many`/`Get for Payee`/`Create`/`Update`/`Delete` to a new Rule resource, wrapping `getRules`/`getPayeeRules`/`createRule`/`updateRule`/`deleteRule`.
- Adds `Get Many`/`Create`/`Update`/`Delete` to a new Schedule resource, wrapping `getSchedules`/`createSchedule`/`updateSchedule`/`deleteSchedule`.

**Design note:** Rule conditions/actions are a deeply nested, polymorphic schema (many condition operators across field types, several action types). Rather than building a bespoke `fixedCollection` UI matching every variant, Create/Update take the rule body as JSON — consistent with how Transactions are already accepted as JSON elsewhere in this node. Schedule's recurring `Date` field (a plain date string or a recur-config object) uses the same JSON approach.

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 75 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rule management for creating, retrieving, updating, and deleting rules.
  * Added scheduled transaction management, including creation, retrieval, updating, and deletion.
  * Added support for payee-specific rules, account and payee settings, amount ranges, dates, posting behavior, and resetting next dates.
  * Added validation for rule data, dates, amounts, and invalid inputs.

* **Tests**
  * Added coverage for rule and schedule operations, including input validation and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->