### PR TITLE
Add Tag and Note resources

### DIFF
--- a/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
+++ b/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
@@ -24,12 +24,20 @@ import {
 	categoryGroupFields,
 	executeCategoryGroup,
 } from './actions/categoryGroup';
+import { noteOperation, noteFields, executeNote } from './actions/note';
 import { payeeOperation, payeeFields, executePayee } from './actions/payee';
 import { ruleOperation, ruleFields, executeRule } from './actions/rule';
 import { scheduleOperation, scheduleFields, executeSchedule } from './actions/schedule';
+import { tagOperation, tagFields, executeTag } from './actions/tag';
 import { transactionOperation, transactionFields, executeTransaction } from './actions/transaction';
 
-import { searchAccounts, searchCategories, searchCategoryGroups, searchPayees } from './methods/listSearch';
+import {
+	searchAccounts,
+	searchCategories,
+	searchCategoryGroups,
+	searchPayees,
+	searchTags,
+} from './methods/listSearch';
 
 export class ActualBudgetV2 implements INodeType {
 	description: INodeTypeDescription = {
@@ -84,6 +92,10 @@ export class ActualBudgetV2 implements INodeType {
 						value: 'categoryGroup',
 					},
 					{
+						name: 'Note',
+						value: 'note',
+					},
+					{
 						name: 'Payee',
 						value: 'payee',
 					},
@@ -94,6 +106,10 @@ export class ActualBudgetV2 implements INodeType {
 					{
 						name: 'Schedule',
 						value: 'schedule',
+					},
+					{
+						name: 'Tag',
+						value: 'tag',
 					},
 					{
 						name: 'Transaction',
@@ -107,17 +123,21 @@ export class ActualBudgetV2 implements INodeType {
 			budgetOperation,
 			categoryOperation,
 			categoryGroupOperation,
+			noteOperation,
 			payeeOperation,
 			ruleOperation,
 			scheduleOperation,
+			tagOperation,
 			transactionOperation,
 			...accountFields,
 			...budgetFields,
 			...categoryFields,
 			...categoryGroupFields,
+			...noteFields,
 			...payeeFields,
 			...ruleFields,
 			...scheduleFields,
+			...tagFields,
 			...transactionFields,
 		],
 		usableAsTool: undefined,
@@ -129,6 +149,7 @@ export class ActualBudgetV2 implements INodeType {
 			searchCategories,
 			searchCategoryGroups,
 			searchPayees,
+			searchTags,
 		},
 	};
 
@@ -211,12 +232,16 @@ async function dispatch(
 			return executeCategory(context, itemIndex, operation);
 		case 'categoryGroup':
 			return executeCategoryGroup(context, itemIndex, operation);
+		case 'note':
+			return executeNote(context, itemIndex, operation);
 		case 'payee':
 			return executePayee(context, itemIndex, operation);
 		case 'rule':
 			return executeRule(context, itemIndex, operation);
 		case 'schedule':
 			return executeSchedule(context, itemIndex, operation);
+		case 'tag':
+			return executeTag(context, itemIndex, operation);
 		case 'transaction':
 			return executeTransaction(context, itemIndex, operation);
 		default:

--- a/nodes/ActualBudget/v2/actions/note.ts
+++ b/nodes/ActualBudget/v2/actions/note.ts
@@ -51,7 +51,7 @@ export const noteFields: INodeProperties[] = [
 			rows: 4,
 		},
 		default: '',
-		required: true,
+		description: 'The note text. Leave empty to clear the note.',
 		displayOptions: {
 			show: {
 				resource: ['note'],

--- a/nodes/ActualBudget/v2/actions/note.ts
+++ b/nodes/ActualBudget/v2/actions/note.ts
@@ -1,0 +1,96 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { getNote, updateNote } from '@actual-app/api';
+
+export const noteOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['note'],
+		},
+	},
+	options: [
+		{
+			name: 'Get',
+			value: 'getNote',
+			action: 'Get the note attached to an entity',
+		},
+		{
+			name: 'Update',
+			value: 'updateNote',
+			action: 'Set the note attached to an entity',
+		},
+	],
+	default: 'getNote',
+};
+
+export const noteFields: INodeProperties[] = [
+	{
+		displayName: 'Entity ID',
+		name: 'entityId',
+		type: 'string',
+		default: '',
+		required: true,
+		description:
+			'The ID of the entity the note is attached to (e.g. an account, category, or transaction ID)',
+		displayOptions: {
+			show: {
+				resource: ['note'],
+				operation: ['getNote', 'updateNote'],
+			},
+		},
+	},
+	{
+		displayName: 'Note',
+		name: 'note',
+		type: 'string',
+		typeOptions: {
+			rows: 4,
+		},
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['note'],
+				operation: ['updateNote'],
+			},
+		},
+	},
+];
+
+export async function executeNote(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getNote':
+			return handleGetNote(context, itemIndex);
+		case 'updateNote':
+			return handleUpdateNote(context, itemIndex);
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown note operation "${operation}"`);
+	}
+}
+
+async function handleGetNote(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const entityId = context.getNodeParameter('entityId', itemIndex) as string;
+	const result = await getNote(entityId);
+	return (result ?? { id: entityId, note: null }) as unknown as IDataObject;
+}
+
+async function handleUpdateNote(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const entityId = context.getNodeParameter('entityId', itemIndex) as string;
+	const note = context.getNodeParameter('note', itemIndex) as string;
+	await updateNote(entityId, note);
+	return { success: true, id: entityId, note };
+}

--- a/nodes/ActualBudget/v2/actions/tag.ts
+++ b/nodes/ActualBudget/v2/actions/tag.ts
@@ -1,0 +1,180 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { createTag, deleteTag, getTags, updateTag } from '@actual-app/api';
+
+import { resourceLocatorField } from '../GenericFunctions';
+
+export const tagOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['tag'],
+		},
+	},
+	options: [
+		{
+			name: 'Create',
+			value: 'createTag',
+			action: 'Create a tag',
+		},
+		{
+			name: 'Delete',
+			value: 'deleteTag',
+			action: 'Delete a tag',
+		},
+		{
+			name: 'Get Many',
+			value: 'getTags',
+			action: 'Get all tags',
+		},
+		{
+			name: 'Update',
+			value: 'updateTag',
+			action: 'Update a tag',
+		},
+	],
+	default: 'getTags',
+};
+
+export const tagFields: INodeProperties[] = [
+	resourceLocatorField({
+		displayName: 'Tag',
+		name: 'tagId',
+		description: 'The Tag to operate on',
+		searchListMethod: 'searchTags',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['tag'],
+				operation: ['updateTag', 'deleteTag'],
+			},
+		},
+	}),
+	{
+		displayName: 'Tag',
+		name: 'tag',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The tag text, e.g. "#reimbursable"',
+		displayOptions: {
+			show: {
+				resource: ['tag'],
+				operation: ['createTag'],
+			},
+		},
+	},
+	{
+		displayName: 'Color',
+		name: 'color',
+		type: 'color',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['tag'],
+				operation: ['createTag'],
+			},
+		},
+	},
+	{
+		displayName: 'Description',
+		name: 'description',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['tag'],
+				operation: ['createTag'],
+			},
+		},
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['tag'],
+				operation: ['updateTag'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Color',
+				name: 'color',
+				type: 'color',
+				default: '',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Tag',
+				name: 'tag',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+export async function executeTag(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'getTags':
+			return (await getTags()) as unknown as IDataObject[];
+		case 'createTag':
+			return handleCreateTag(context, itemIndex);
+		case 'updateTag':
+			return handleUpdateTag(context, itemIndex);
+		case 'deleteTag':
+			return handleDeleteTag(context, itemIndex);
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown tag operation "${operation}"`);
+	}
+}
+
+function getTagId(context: IExecuteFunctions, itemIndex: number): string {
+	return context.getNodeParameter('tagId', itemIndex, undefined, { extractValue: true }) as string;
+}
+
+async function handleCreateTag(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const tag = context.getNodeParameter('tag', itemIndex) as string;
+	const color = context.getNodeParameter('color', itemIndex) as string;
+	const description = context.getNodeParameter('description', itemIndex) as string;
+	const id = await createTag({ tag, color, description });
+	return { id, tag, color, description };
+}
+
+async function handleUpdateTag(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getTagId(context, itemIndex);
+	const fields = context.getNodeParameter('updateFields', itemIndex) as IDataObject;
+	await updateTag(id, fields);
+	return { success: true, id, ...fields };
+}
+
+async function handleDeleteTag(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const id = getTagId(context, itemIndex);
+	await deleteTag(id);
+	return { success: true, id };
+}

--- a/nodes/ActualBudget/v2/methods/listSearch.ts
+++ b/nodes/ActualBudget/v2/methods/listSearch.ts
@@ -1,6 +1,6 @@
 import { ILoadOptionsFunctions, INodeListSearchResult } from 'n8n-workflow';
 
-import { getAccounts, getCategoryGroups, getPayees } from '@actual-app/api';
+import { getAccounts, getCategoryGroups, getPayees, getTags } from '@actual-app/api';
 
 import { Credentials, withBudgetSession } from '../GenericFunctions';
 
@@ -71,5 +71,18 @@ export async function searchCategoryGroups(
 		results: groups
 			.filter((group) => matchesFilter(group.name, filter))
 			.map((group) => ({ name: group.name, value: group.id })),
+	};
+}
+
+export async function searchTags(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const { auth, budgetId } = await getAuthAndBudget(this);
+	const tags = await withBudgetSession(auth, budgetId, () => getTags());
+	return {
+		results: tags
+			.filter((tag) => matchesFilter(tag.tag, filter))
+			.map((tag) => ({ name: tag.tag, value: tag.id })),
 	};
 }

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -1541,6 +1541,21 @@ describe("ActualBudget", () => {
 
       expect(actualApi.updateNote).toHaveBeenCalledWith("acc-1", "New note text");
     });
+
+    it("should allow clearing a note by passing an empty string", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateNote";
+        if (name === "resource") return "note";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "entityId") return "acc-1";
+        if (name === "note") return "";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateNote).toHaveBeenCalledWith("acc-1", "");
+    });
   });
 
   describe("concurrent executions", () => {

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -69,6 +69,12 @@ vi.mock("@actual-app/api", () => ({
   createSchedule: vi.fn().mockResolvedValue("sched-new"),
   updateSchedule: vi.fn().mockResolvedValue("sched-1"),
   deleteSchedule: vi.fn().mockResolvedValue(undefined),
+  getTags: vi.fn().mockResolvedValue([{ id: "tag-1", tag: "#reimbursable", color: "", description: "" }]),
+  createTag: vi.fn().mockResolvedValue("tag-new"),
+  updateTag: vi.fn().mockResolvedValue(undefined),
+  deleteTag: vi.fn().mockResolvedValue(undefined),
+  getNote: vi.fn().mockResolvedValue({ id: "acc-1", note: "Existing note" }),
+  updateNote: vi.fn().mockResolvedValue(undefined),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -1437,6 +1443,103 @@ describe("ActualBudget", () => {
       await node.execute.call(executeFunctions);
 
       expect(actualApi.deleteSchedule).toHaveBeenCalledWith("sched-1");
+    });
+  });
+
+  describe("tag resource", () => {
+    it("should call getTags and return each tag as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getTags";
+        if (name === "resource") return "tag";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getTags).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+    });
+
+    it("should call createTag with tag, color, and description", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createTag";
+        if (name === "resource") return "tag";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "tag") return "#travel";
+        if (name === "color") return "#ff0000";
+        if (name === "description") return "Travel expenses";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.createTag).toHaveBeenCalledWith({
+        tag: "#travel",
+        color: "#ff0000",
+        description: "Travel expenses",
+      });
+    });
+
+    it("should call updateTag with the resolved tag ID and update fields", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateTag";
+        if (name === "resource") return "tag";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "tagId") return "tag-1";
+        if (name === "updateFields") return { color: "#00ff00" };
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateTag).toHaveBeenCalledWith("tag-1", { color: "#00ff00" });
+    });
+
+    it("should call deleteTag with the resolved tag ID", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "deleteTag";
+        if (name === "resource") return "tag";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "tagId") return "tag-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.deleteTag).toHaveBeenCalledWith("tag-1");
+    });
+  });
+
+  describe("note resource", () => {
+    it("should call getNote with the entity ID and return the note", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getNote";
+        if (name === "resource") return "note";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "entityId") return "acc-1";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getNote).toHaveBeenCalledWith("acc-1");
+      expect(result[0][0].json).toEqual({ id: "acc-1", note: "Existing note" });
+    });
+
+    it("should call updateNote with the entity ID and note text", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "updateNote";
+        if (name === "resource") return "note";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "entityId") return "acc-1";
+        if (name === "note") return "New note text";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.updateNote).toHaveBeenCalledWith("acc-1", "New note text");
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ActualBudgetV2 } from "../nodes/ActualBudget/v2/ActualBudgetV2.node";
+import { noteFields } from "../nodes/ActualBudget/v2/actions/note";
 import type { IDataObject, IExecuteFunctions } from "n8n-workflow";
 
 vi.mock("@actual-app/api", () => ({
@@ -1555,6 +1556,11 @@ describe("ActualBudget", () => {
       await node.execute.call(executeFunctions);
 
       expect(actualApi.updateNote).toHaveBeenCalledWith("acc-1", "");
+    });
+
+    it("note field definition should not mark 'note' as required, so empty strings pass n8n's own validation", () => {
+      const noteField = noteFields.find((field) => field.name === "note");
+      expect(noteField?.required).not.toBe(true);
     });
   });
 

--- a/tests/listSearch.spec.ts
+++ b/tests/listSearch.spec.ts
@@ -24,9 +24,13 @@ vi.mock("@actual-app/api", () => ({
     },
     { id: "grp-2", name: "Bills", categories: [{ id: "cat-3", name: "Electricity" }] },
   ]),
+  getTags: vi.fn().mockResolvedValue([
+    { id: "tag-1", tag: "#reimbursable" },
+    { id: "tag-2", tag: "#travel" },
+  ]),
 }));
 
-import { searchAccounts, searchPayees, searchCategories, searchCategoryGroups } from "../nodes/ActualBudget/v2/methods/listSearch";
+import { searchAccounts, searchPayees, searchCategories, searchCategoryGroups, searchTags } from "../nodes/ActualBudget/v2/methods/listSearch";
 
 function makeLoadOptionsContext(budgetId: string): ILoadOptionsFunctions {
   return {
@@ -72,5 +76,13 @@ describe("listSearch methods", () => {
   it("searchCategories flattens categories under their group name and filters by category name", async () => {
     const result = await searchCategories.call(makeLoadOptionsContext("budget-1"), "grocer");
     expect(result.results).toEqual([{ name: "Food / Groceries", value: "cat-1" }]);
+  });
+
+  it("searchTags returns all tags mapped to name/value", async () => {
+    const result = await searchTags.call(makeLoadOptionsContext("budget-1"));
+    expect(result.results).toEqual([
+      { name: "#reimbursable", value: "tag-1" },
+      { name: "#travel", value: "tag-2" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
Stacked on #221.

- Adds `Create`/`Update`/`Delete`/`Get Many` to a new Tag resource, wrapping `createTag`/`updateTag`/`deleteTag`/`getTags`, with a new `searchTags` listSearch method backing a resourceLocator field (same pattern as Account/Category/Payee).
- Adds `Get`/`Update` to a new Note resource, wrapping `getNote`/`updateNote`. Notes attach to any entity (account, category, transaction, ...), so unlike the other resources there's no single searchable source — the entity ID is a plain string field.

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 82 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag management with create, retrieve, update, delete, and list operations.
  * Added tag search support for easier tag selection.
  * Added note retrieval and update operations for supported entities.
  * Note updates report success, while missing notes return an empty result.

* **Tests**
  * Added coverage for tag and note operations, including search results and API parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->