### PR TITLE
Add remaining budget mechanics and sync operations

### DIFF
--- a/nodes/ActualBudget/v2/actions/budget.ts
+++ b/nodes/ActualBudget/v2/actions/budget.ts
@@ -5,7 +5,19 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 
-import { getBudgetMonth, setBudgetAmount } from '@actual-app/api';
+import {
+	getBudgetMonth,
+	getBudgetMonths,
+	getBudgets,
+	getPreferences,
+	getServerVersion,
+	holdBudgetForNextMonth,
+	resetBudgetHold,
+	runBankSync,
+	setBudgetAmount,
+	setBudgetCarryover,
+	sync,
+} from '@actual-app/api';
 
 import { resourceLocatorField } from '../GenericFunctions';
 
@@ -21,14 +33,59 @@ export const budgetOperation: INodeProperties = {
 	},
 	options: [
 		{
+			name: 'Get Budget Files',
+			value: 'getBudgets',
+			action: 'Get all budget files available on the server',
+		},
+		{
 			name: 'Get Month',
 			value: 'getBudgetMonth',
 			action: 'Get budget data for a specific month',
 		},
 		{
+			name: 'Get Months',
+			value: 'getBudgetMonths',
+			action: 'Get all budget months',
+		},
+		{
+			name: 'Get Preferences',
+			value: 'getPreferences',
+			action: 'Get the synced budget preferences',
+		},
+		{
+			name: 'Get Server Version',
+			value: 'getServerVersion',
+			action: 'Get the actual server version',
+		},
+		{
+			name: 'Hold for Next Month',
+			value: 'holdBudgetForNextMonth',
+			action: 'Hold available funds for next month',
+		},
+		{
+			name: 'Reset Hold',
+			value: 'resetBudgetHold',
+			action: 'Reset the hold for next month',
+		},
+		{
+			name: 'Run Bank Sync',
+			value: 'runBankSync',
+			action: 'Sync bank linked accounts',
+		},
+		{
 			name: 'Set Amount',
 			value: 'setBudgetAmount',
 			action: 'Set the budget amount for a category in a specific month',
+		},
+		{
+			name: 'Set Carryover',
+			value: 'setBudgetCarryover',
+			action: 'Set the carryover flag for a category in a specific month',
+		},
+		{
+			name: 'Sync',
+			value: 'sync',
+			action: 'Sync the current budget',
 		},
 	],
 	default: 'getBudgetMonth',
@@ -45,7 +102,13 @@ export const budgetFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['budget'],
-				operation: ['getBudgetMonth', 'setBudgetAmount'],
+				operation: [
+					'getBudgetMonth',
+					'setBudgetAmount',
+					'setBudgetCarryover',
+					'holdBudgetForNextMonth',
+					'resetBudgetHold',
+				],
 			},
 		},
 	},
@@ -58,7 +121,7 @@ export const budgetFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['budget'],
-				operation: ['setBudgetAmount'],
+				operation: ['setBudgetAmount', 'setBudgetCarryover'],
 			},
 		},
 	}),
@@ -72,10 +135,35 @@ export const budgetFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['budget'],
-				operation: ['setBudgetAmount'],
+				operation: ['setBudgetAmount', 'holdBudgetForNextMonth'],
 			},
 		},
 	},
+	{
+		displayName: 'Carryover',
+		name: 'carryover',
+		type: 'boolean',
+		default: true,
+		description: 'Whether to carry over this category\'s balance into the next month',
+		displayOptions: {
+			show: {
+				resource: ['budget'],
+				operation: ['setBudgetCarryover'],
+			},
+		},
+	},
+	resourceLocatorField({
+		displayName: 'Account',
+		name: 'accountId',
+		description: 'The Account to sync (leave empty to sync all bank-linked accounts)',
+		searchListMethod: 'searchAccounts',
+		displayOptions: {
+			show: {
+				resource: ['budget'],
+				operation: ['runBankSync'],
+			},
+		},
+	}),
 ];
 
 export async function executeBudget(
@@ -88,6 +176,25 @@ export async function executeBudget(
 			return handleGetBudgetMonth(context, itemIndex);
 		case 'setBudgetAmount':
 			return handleSetBudgetAmount(context, itemIndex);
+		case 'setBudgetCarryover':
+			return handleSetBudgetCarryover(context, itemIndex);
+		case 'holdBudgetForNextMonth':
+			return handleHoldBudgetForNextMonth(context, itemIndex);
+		case 'resetBudgetHold':
+			return handleResetBudgetHold(context, itemIndex);
+		case 'getBudgetMonths':
+			return (await getBudgetMonths()) as unknown as IDataObject[];
+		case 'getBudgets':
+			return (await getBudgets()) as unknown as IDataObject[];
+		case 'sync':
+			await sync();
+			return { success: true };
+		case 'runBankSync':
+			return handleRunBankSync(context, itemIndex);
+		case 'getServerVersion':
+			return (await getServerVersion()) as unknown as IDataObject;
+		case 'getPreferences':
+			return (await getPreferences()) as unknown as IDataObject;
 		default:
 			throw new NodeOperationError(context.getNode(), `Unknown budget operation "${operation}"`);
 	}
@@ -115,4 +222,47 @@ async function handleSetBudgetAmount(
 	}
 	await setBudgetAmount(month, categoryId, amount);
 	return { success: true, month, categoryId, amount };
+}
+
+async function handleSetBudgetCarryover(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const month = context.getNodeParameter('month', itemIndex) as string;
+	const categoryId = context.getNodeParameter('categoryId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	const carryover = context.getNodeParameter('carryover', itemIndex) as boolean;
+	await setBudgetCarryover(month, categoryId, carryover);
+	return { success: true, month, categoryId, carryover };
+}
+
+async function handleHoldBudgetForNextMonth(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const month = context.getNodeParameter('month', itemIndex) as string;
+	const amount = context.getNodeParameter('amount', itemIndex) as number;
+	const success = await holdBudgetForNextMonth(month, amount);
+	return { success, month, amount };
+}
+
+async function handleResetBudgetHold(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const month = context.getNodeParameter('month', itemIndex) as string;
+	await resetBudgetHold(month);
+	return { success: true, month };
+}
+
+async function handleRunBankSync(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const accountId = context.getNodeParameter('accountId', itemIndex, undefined, {
+		extractValue: true,
+	}) as string;
+	await runBankSync(accountId ? { accountId } : undefined);
+	return { success: true, accountId: accountId || null };
 }

--- a/nodes/ActualBudget/v2/actions/budget.ts
+++ b/nodes/ActualBudget/v2/actions/budget.ts
@@ -183,7 +183,7 @@ export async function executeBudget(
 		case 'resetBudgetHold':
 			return handleResetBudgetHold(context, itemIndex);
 		case 'getBudgetMonths':
-			return (await getBudgetMonths()) as unknown as IDataObject[];
+			return (await getBudgetMonths()).map((month) => ({ month }));
 		case 'getBudgets':
 			return (await getBudgets()) as unknown as IDataObject[];
 		case 'sync':
@@ -243,6 +243,9 @@ async function handleHoldBudgetForNextMonth(
 ): Promise<IDataObject> {
 	const month = context.getNodeParameter('month', itemIndex) as string;
 	const amount = context.getNodeParameter('amount', itemIndex) as number;
+	if (!Number.isInteger(amount)) {
+		throw new NodeOperationError(context.getNode(), '"amount" must be an integer number of millicents');
+	}
 	const success = await holdBudgetForNextMonth(month, amount);
 	return { success, month, amount };
 }

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -76,6 +76,15 @@ vi.mock("@actual-app/api", () => ({
   deleteTag: vi.fn().mockResolvedValue(undefined),
   getNote: vi.fn().mockResolvedValue({ id: "acc-1", note: "Existing note" }),
   updateNote: vi.fn().mockResolvedValue(undefined),
+  getBudgetMonths: vi.fn().mockResolvedValue(["2024-01", "2024-02", "2024-03"]),
+  getBudgets: vi.fn().mockResolvedValue([{ id: "file-1", name: "My Budget", cloudFileId: "cloud-1" }]),
+  getPreferences: vi.fn().mockResolvedValue({ dateFormat: "MM/dd/yyyy" }),
+  getServerVersion: vi.fn().mockResolvedValue({ version: "25.0.0" }),
+  setBudgetCarryover: vi.fn().mockResolvedValue(undefined),
+  holdBudgetForNextMonth: vi.fn().mockResolvedValue(true),
+  resetBudgetHold: vi.fn().mockResolvedValue(undefined),
+  runBankSync: vi.fn().mockResolvedValue(undefined),
+  sync: vi.fn().mockResolvedValue(undefined),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -753,6 +762,152 @@ describe("ActualBudget", () => {
 
       expect(result).toBeDefined();
       expect(actualApi.shutdown).toHaveBeenCalled();
+    });
+  });
+
+  describe("budget mechanics operations", () => {
+    it("should call getBudgetMonths and return each month as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getBudgetMonths";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getBudgetMonths).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(3);
+    });
+
+    it("should call getBudgets and return each budget file as a separate output item", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getBudgets";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getBudgets).toHaveBeenCalled();
+      expect(result[0]).toHaveLength(1);
+    });
+
+    it("should call getPreferences", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getPreferences";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getPreferences).toHaveBeenCalled();
+      expect(result[0][0].json).toEqual({ dateFormat: "MM/dd/yyyy" });
+    });
+
+    it("should call getServerVersion", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "getServerVersion";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.getServerVersion).toHaveBeenCalled();
+      expect(result[0][0].json).toEqual({ version: "25.0.0" });
+    });
+
+    it("should call setBudgetCarryover with month, categoryId, and carryover flag", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "setBudgetCarryover";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        if (name === "categoryId") return "cat-abc";
+        if (name === "carryover") return true;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.setBudgetCarryover).toHaveBeenCalledWith("2024-03", "cat-abc", true);
+    });
+
+    it("should call holdBudgetForNextMonth with month and amount", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "holdBudgetForNextMonth";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        if (name === "amount") return 20000;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.holdBudgetForNextMonth).toHaveBeenCalledWith("2024-03", 20000);
+      expect(result[0][0].json).toEqual({ success: true, month: "2024-03", amount: 20000 });
+    });
+
+    it("should call resetBudgetHold with month", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "resetBudgetHold";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.resetBudgetHold).toHaveBeenCalledWith("2024-03");
+    });
+
+    it("should call sync", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "sync";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(actualApi.sync).toHaveBeenCalled();
+      expect(result[0][0].json).toEqual({ success: true });
+    });
+
+    it("should call runBankSync with the resolved account ID when provided", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runBankSync";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "acc-1";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.runBankSync).toHaveBeenCalledWith({ accountId: "acc-1" });
+    });
+
+    it("should call runBankSync with no args when account is not provided", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runBankSync";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "accountId") return "";
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.runBankSync).toHaveBeenCalledWith(undefined);
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -777,7 +777,11 @@ describe("ActualBudget", () => {
       const result = await node.execute.call(executeFunctions);
 
       expect(actualApi.getBudgetMonths).toHaveBeenCalled();
-      expect(result[0]).toHaveLength(3);
+      expect(result[0].map((item) => item.json)).toEqual([
+        { month: "2024-01" },
+        { month: "2024-02" },
+        { month: "2024-03" },
+      ]);
     });
 
     it("should call getBudgets and return each budget file as a separate output item", async () => {
@@ -852,6 +856,22 @@ describe("ActualBudget", () => {
 
       expect(actualApi.holdBudgetForNextMonth).toHaveBeenCalledWith("2024-03", 20000);
       expect(result[0][0].json).toEqual({ success: true, month: "2024-03", amount: 20000 });
+    });
+
+    it("should reject a fractional amount for holdBudgetForNextMonth", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "holdBudgetForNextMonth";
+        if (name === "resource") return "budget";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "month") return "2024-03";
+        if (name === "amount") return 200.5;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+        '"amount" must be an integer number of millicents',
+      );
+      expect(actualApi.holdBudgetForNextMonth).not.toHaveBeenCalled();
     });
 
     it("should call resetBudgetHold with month", async () => {


### PR DESCRIPTION
## Summary
Stacked on #222.

Adds to the Budget resource:
- `Get Months`, `Get Budget Files`, `Get Preferences`, `Get Server Version` (read-only)
- `Set Carryover`, `Hold for Next Month`, `Reset Hold` (budget-month mechanics)
- `Sync`, `Run Bank Sync` (sync operations)

wrapping `getBudgetMonths`/`getBudgets`/`getPreferences`/`getServerVersion`/`setBudgetCarryover`/`holdBudgetForNextMonth`/`resetBudgetHold`/`sync`/`runBankSync`.

**Scope note:** deliberately does not wrap multi-item executions in `batchBudgetUpdates` — that's a performance optimization for bulk budget-month writes, not a functional gap (each operation already works correctly on its own), and didn't seem worth the added dispatch-loop complexity for what's expected to be low-volume usage in a workflow-automation context. Also out of scope: `importBudget`/`exportBudget`, which deal in binary buffers and would need n8n's binary-data handling to do properly — a larger, separate piece of work if wanted later.

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 92 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added budget tools to retrieve budgets, months, preferences, and server version information.
  * Added options to synchronize budgets and bank-linked accounts.
  * Added support for setting carryover amounts and holding or resetting funds for the next month.

* **Bug Fixes**
  * Improved handling of bank synchronization with or without a selected account.
  * Added validation to reject fractional amounts when holding funds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->