### PR TITLE
Add generic AQL Query resource

### DIFF
--- a/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
+++ b/nodes/ActualBudget/v2/ActualBudgetV2.node.ts
@@ -26,6 +26,7 @@ import {
 } from './actions/categoryGroup';
 import { noteOperation, noteFields, executeNote } from './actions/note';
 import { payeeOperation, payeeFields, executePayee } from './actions/payee';
+import { queryOperation, queryFields, executeQuery } from './actions/query';
 import { ruleOperation, ruleFields, executeRule } from './actions/rule';
 import { scheduleOperation, scheduleFields, executeSchedule } from './actions/schedule';
 import { tagOperation, tagFields, executeTag } from './actions/tag';
@@ -100,6 +101,10 @@ export class ActualBudgetV2 implements INodeType {
 						value: 'payee',
 					},
 					{
+						name: 'Query',
+						value: 'query',
+					},
+					{
 						name: 'Rule',
 						value: 'rule',
 					},
@@ -125,6 +130,7 @@ export class ActualBudgetV2 implements INodeType {
 			categoryGroupOperation,
 			noteOperation,
 			payeeOperation,
+			queryOperation,
 			ruleOperation,
 			scheduleOperation,
 			tagOperation,
@@ -135,6 +141,7 @@ export class ActualBudgetV2 implements INodeType {
 			...categoryGroupFields,
 			...noteFields,
 			...payeeFields,
+			...queryFields,
 			...ruleFields,
 			...scheduleFields,
 			...tagFields,
@@ -236,6 +243,8 @@ async function dispatch(
 			return executeNote(context, itemIndex, operation);
 		case 'payee':
 			return executePayee(context, itemIndex, operation);
+		case 'query':
+			return executeQuery(context, itemIndex, operation);
 		case 'rule':
 			return executeRule(context, itemIndex, operation);
 		case 'schedule':

--- a/nodes/ActualBudget/v2/actions/query.ts
+++ b/nodes/ActualBudget/v2/actions/query.ts
@@ -1,0 +1,177 @@
+import { IDataObject, IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
+
+import { aqlQuery, q } from '@actual-app/api';
+
+export const queryOperation: INodeProperties = {
+	displayName: 'Operation',
+	name: 'operation',
+	type: 'options',
+	noDataExpression: true,
+	displayOptions: {
+		show: {
+			resource: ['query'],
+		},
+	},
+	options: [
+		{
+			name: 'Run',
+			value: 'runQuery',
+			action: 'Run a custom AQL query',
+		},
+	],
+	default: 'runQuery',
+};
+
+export const queryFields: INodeProperties[] = [
+	{
+		displayName: 'Table',
+		name: 'table',
+		type: 'string',
+		default: 'transactions',
+		required: true,
+		description: 'The table to query, e.g. "transactions", "accounts", "categories", "payees"',
+		displayOptions: {
+			show: {
+				resource: ['query'],
+				operation: ['runQuery'],
+			},
+		},
+	},
+	{
+		displayName: 'Filter',
+		name: 'filter',
+		type: 'json',
+		default: '{}',
+		description: 'AQL filter expression object, e.g. {"date": {"$gte": "2024-01-01"}}',
+		displayOptions: {
+			show: {
+				resource: ['query'],
+				operation: ['runQuery'],
+			},
+		},
+	},
+	{
+		displayName: 'Select',
+		name: 'select',
+		type: 'json',
+		default: '"*"',
+		description: 'Fields to select: "*", a field name, or a JSON array of fields/expressions',
+		displayOptions: {
+			show: {
+				resource: ['query'],
+				operation: ['runQuery'],
+			},
+		},
+	},
+	{
+		displayName: 'Group By',
+		name: 'groupBy',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of fields/expressions to group by, if any',
+		displayOptions: {
+			show: {
+				resource: ['query'],
+				operation: ['runQuery'],
+			},
+		},
+	},
+	{
+		displayName: 'Order By',
+		name: 'orderBy',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of fields/expressions to order by, if any',
+		displayOptions: {
+			show: {
+				resource: ['query'],
+				operation: ['runQuery'],
+			},
+		},
+	},
+	{
+		displayName: 'Limit',
+		name: 'rowLimit',
+		type: 'number',
+		default: 0,
+		description: 'Max number of rows to return (0 = no limit)',
+		displayOptions: {
+			show: {
+				resource: ['query'],
+				operation: ['runQuery'],
+			},
+		},
+	},
+	{
+		displayName: 'Offset',
+		name: 'offset',
+		type: 'number',
+		default: 0,
+		description: 'Number of rows to skip (0 = none)',
+		displayOptions: {
+			show: {
+				resource: ['query'],
+				operation: ['runQuery'],
+			},
+		},
+	},
+];
+
+function parseJsonParam(context: IExecuteFunctions, name: string, itemIndex: number): unknown {
+	const raw = context.getNodeParameter(name, itemIndex);
+	if (typeof raw !== 'string') return raw;
+	try {
+		return JSON.parse(raw);
+	} catch {
+		throw new NodeOperationError(context.getNode(), `"${name}" field contains invalid JSON`);
+	}
+}
+
+export async function executeQuery(
+	context: IExecuteFunctions,
+	itemIndex: number,
+	operation: string,
+): Promise<IDataObject | IDataObject[]> {
+	switch (operation) {
+		case 'runQuery':
+			return handleRunQuery(context, itemIndex);
+		default:
+			throw new NodeOperationError(context.getNode(), `Unknown query operation "${operation}"`);
+	}
+}
+
+async function handleRunQuery(
+	context: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject | IDataObject[]> {
+	const table = context.getNodeParameter('table', itemIndex) as string;
+	const filter = parseJsonParam(context, 'filter', itemIndex) as Record<string, unknown>;
+	const select = parseJsonParam(context, 'select', itemIndex) as string | unknown[];
+	const groupBy = parseJsonParam(context, 'groupBy', itemIndex) as unknown[];
+	const orderBy = parseJsonParam(context, 'orderBy', itemIndex) as unknown[];
+	const limit = context.getNodeParameter('rowLimit', itemIndex) as number;
+	const offset = context.getNodeParameter('offset', itemIndex) as number;
+
+	let query = q(table);
+	if (filter && Object.keys(filter).length > 0) {
+		query = query.filter(filter);
+	}
+	if (Array.isArray(select) ? select.length > 0 : Boolean(select)) {
+		query = query.select(select as never);
+	}
+	if (Array.isArray(groupBy) && groupBy.length > 0) {
+		query = query.groupBy(groupBy as never);
+	}
+	if (Array.isArray(orderBy) && orderBy.length > 0) {
+		query = query.orderBy(orderBy as never);
+	}
+	if (limit > 0) {
+		query = query.limit(limit);
+	}
+	if (offset > 0) {
+		query = query.offset(offset);
+	}
+
+	const result = await aqlQuery(query);
+	return (Array.isArray(result) ? result : (result as IDataObject)) as IDataObject | IDataObject[];
+}

--- a/nodes/ActualBudget/v2/actions/query.ts
+++ b/nodes/ActualBudget/v2/actions/query.ts
@@ -172,6 +172,6 @@ async function handleRunQuery(
 		query = query.offset(offset);
 	}
 
-	const result = await aqlQuery(query);
-	return (Array.isArray(result) ? result : (result as IDataObject)) as IDataObject | IDataObject[];
+	const { data } = (await aqlQuery(query)) as { data: IDataObject[] };
+	return data;
 }

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -85,6 +85,8 @@ vi.mock("@actual-app/api", () => ({
   resetBudgetHold: vi.fn().mockResolvedValue(undefined),
   runBankSync: vi.fn().mockResolvedValue(undefined),
   sync: vi.fn().mockResolvedValue(undefined),
+  q: vi.fn(),
+  aqlQuery: vi.fn().mockResolvedValue([]),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -1736,6 +1738,123 @@ describe("ActualBudget", () => {
     it("note field definition should not mark 'note' as required, so empty strings pass n8n's own validation", () => {
       const noteField = noteFields.find((field) => field.name === "note");
       expect(noteField?.required).not.toBe(true);
+    });
+  });
+
+  describe("query resource", () => {
+    function createFakeQuery() {
+      const fake: Record<string, unknown> = {};
+      for (const method of ["filter", "select", "groupBy", "orderBy", "limit", "offset"]) {
+        fake[method] = vi.fn().mockReturnValue(fake);
+      }
+      return fake as {
+        filter: ReturnType<typeof vi.fn>;
+        select: ReturnType<typeof vi.fn>;
+        groupBy: ReturnType<typeof vi.fn>;
+        orderBy: ReturnType<typeof vi.fn>;
+        limit: ReturnType<typeof vi.fn>;
+        offset: ReturnType<typeof vi.fn>;
+      };
+    }
+
+    let fakeQuery: ReturnType<typeof createFakeQuery>;
+
+    beforeEach(() => {
+      fakeQuery = createFakeQuery();
+      vi.mocked(actualApi.q).mockReturnValue(fakeQuery as unknown as ReturnType<typeof actualApi.q>);
+    });
+
+    it("should build the query from table/filter/select and call aqlQuery", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runQuery";
+        if (name === "resource") return "query";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "table") return "transactions";
+        if (name === "filter") return '{"amount": {"$lt": 0}}';
+        if (name === "select") return '["date", "amount"]';
+        if (name === "groupBy") return "[]";
+        if (name === "orderBy") return "[]";
+        if (name === "rowLimit") return 0;
+        if (name === "offset") return 0;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(actualApi.q).toHaveBeenCalledWith("transactions");
+      expect(fakeQuery.filter).toHaveBeenCalledWith({ amount: { $lt: 0 } });
+      expect(fakeQuery.select).toHaveBeenCalledWith(["date", "amount"]);
+      expect(fakeQuery.groupBy).not.toHaveBeenCalled();
+      expect(fakeQuery.orderBy).not.toHaveBeenCalled();
+      expect(fakeQuery.limit).not.toHaveBeenCalled();
+      expect(fakeQuery.offset).not.toHaveBeenCalled();
+      expect(actualApi.aqlQuery).toHaveBeenCalledWith(fakeQuery);
+    });
+
+    it("should apply groupBy/orderBy/limit/offset when provided", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runQuery";
+        if (name === "resource") return "query";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "table") return "transactions";
+        if (name === "filter") return "{}";
+        if (name === "select") return '"*"';
+        if (name === "groupBy") return '["category"]';
+        if (name === "orderBy") return '["date"]';
+        if (name === "rowLimit") return 10;
+        if (name === "offset") return 5;
+        return undefined;
+      });
+
+      await node.execute.call(executeFunctions);
+
+      expect(fakeQuery.filter).not.toHaveBeenCalled();
+      expect(fakeQuery.groupBy).toHaveBeenCalledWith(["category"]);
+      expect(fakeQuery.orderBy).toHaveBeenCalledWith(["date"]);
+      expect(fakeQuery.limit).toHaveBeenCalledWith(10);
+      expect(fakeQuery.offset).toHaveBeenCalledWith(5);
+    });
+
+    it("should throw on invalid filter JSON", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runQuery";
+        if (name === "resource") return "query";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "table") return "transactions";
+        if (name === "filter") return "not json";
+        if (name === "select") return '"*"';
+        if (name === "groupBy") return "[]";
+        if (name === "orderBy") return "[]";
+        if (name === "rowLimit") return 0;
+        if (name === "offset") return 0;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/invalid JSON/);
+    });
+
+    it("should return each row as a separate output item when aqlQuery resolves an array", async () => {
+      vi.mocked(actualApi.aqlQuery).mockResolvedValueOnce([
+        { date: "2024-01-01", amount: -100 },
+        { date: "2024-01-02", amount: -200 },
+      ]);
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runQuery";
+        if (name === "resource") return "query";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "table") return "transactions";
+        if (name === "filter") return "{}";
+        if (name === "select") return '"*"';
+        if (name === "groupBy") return "[]";
+        if (name === "orderBy") return "[]";
+        if (name === "rowLimit") return 0;
+        if (name === "offset") return 0;
+        return undefined;
+      });
+
+      const result = await node.execute.call(executeFunctions);
+
+      expect(result[0]).toHaveLength(2);
     });
   });
 

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -86,7 +86,7 @@ vi.mock("@actual-app/api", () => ({
   runBankSync: vi.fn().mockResolvedValue(undefined),
   sync: vi.fn().mockResolvedValue(undefined),
   q: vi.fn(),
-  aqlQuery: vi.fn().mockResolvedValue([]),
+  aqlQuery: vi.fn().mockResolvedValue({ data: [], dependencies: [] }),
 }));
 
 import * as actualApi from "@actual-app/api";
@@ -1833,11 +1833,14 @@ describe("ActualBudget", () => {
       await expect(node.execute.call(executeFunctions)).rejects.toThrow(/invalid JSON/);
     });
 
-    it("should return each row as a separate output item when aqlQuery resolves an array", async () => {
-      vi.mocked(actualApi.aqlQuery).mockResolvedValueOnce([
-        { date: "2024-01-01", amount: -100 },
-        { date: "2024-01-02", amount: -200 },
-      ]);
+    it("should unwrap the { data, dependencies } envelope and return each row as a separate output item", async () => {
+      vi.mocked(actualApi.aqlQuery).mockResolvedValueOnce({
+        data: [
+          { date: "2024-01-01", amount: -100 },
+          { date: "2024-01-02", amount: -200 },
+        ],
+        dependencies: ["transactions"],
+      });
       executeFunctions.getNodeParameter.mockImplementation((name: string) => {
         if (name === "operation") return "runQuery";
         if (name === "resource") return "query";
@@ -1854,7 +1857,10 @@ describe("ActualBudget", () => {
 
       const result = await node.execute.call(executeFunctions);
 
-      expect(result[0]).toHaveLength(2);
+      expect(result[0].map((item) => item.json)).toEqual([
+        { date: "2024-01-01", amount: -100 },
+        { date: "2024-01-02", amount: -200 },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
Stacked on #223. Last PR in the API-surface-expansion stack (#215-#224).

- Adds a `Query` resource with a single `Run` operation exposing `Table`, `Filter`, `Select`, `Group By`, `Order By`, `Limit`, `Offset` fields, building an ActualQL query via `q(table)...` and executing it with `aqlQuery()` (explicitly not the deprecated `runQuery()`).
- Intended as a power-user escape hatch for lookups/aggregations the other typed resources don't cover directly (e.g. custom filters, grouped sums).

## Test plan
- [x] `npm run lint` — clean (pre-existing icon-variant warning only)
- [x] `npm run test:run` — 96 passed, 6 skipped (integration, requires a live server)
- [x] `npm run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added query support to the Actual Budget integration.
  * Configure tables, filters, selected fields, grouping, ordering, result limits, and offsets.
  * Query results are returned as separate output items when applicable.
  * Added clear errors for invalid filter JSON and unsupported operations.
  * Supports flexible data retrieval with optional query parameters for more targeted results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->