### PR TITLE
Close edge-case and integration coverage gaps: Query validation, Account/Category/CategoryGroup/Payee, real-error tests

### DIFF
--- a/nodes/ActualBudget/v2/actions/query.ts
+++ b/nodes/ActualBudget/v2/actions/query.ts
@@ -127,6 +127,18 @@ function parseJsonParam(context: IExecuteFunctions, name: string, itemIndex: num
 	}
 }
 
+function parseJsonArrayParam(
+	context: IExecuteFunctions,
+	name: string,
+	itemIndex: number,
+): unknown[] {
+	const parsed = parseJsonParam(context, name, itemIndex);
+	if (!Array.isArray(parsed)) {
+		throw new NodeOperationError(context.getNode(), `"${name}" must be a JSON array`);
+	}
+	return parsed;
+}
+
 export async function executeQuery(
 	context: IExecuteFunctions,
 	itemIndex: number,
@@ -147,8 +159,8 @@ async function handleRunQuery(
 	const table = context.getNodeParameter('table', itemIndex) as string;
 	const filter = parseJsonParam(context, 'filter', itemIndex) as Record<string, unknown>;
 	const select = parseJsonParam(context, 'select', itemIndex) as string | unknown[];
-	const groupBy = parseJsonParam(context, 'groupBy', itemIndex) as unknown[];
-	const orderBy = parseJsonParam(context, 'orderBy', itemIndex) as unknown[];
+	const groupBy = parseJsonArrayParam(context, 'groupBy', itemIndex);
+	const orderBy = parseJsonArrayParam(context, 'orderBy', itemIndex);
 	const limit = context.getNodeParameter('rowLimit', itemIndex) as number;
 	const offset = context.getNodeParameter('offset', itemIndex) as number;
 
@@ -159,10 +171,10 @@ async function handleRunQuery(
 	if (Array.isArray(select) ? select.length > 0 : Boolean(select)) {
 		query = query.select(select as never);
 	}
-	if (Array.isArray(groupBy) && groupBy.length > 0) {
+	if (groupBy.length > 0) {
 		query = query.groupBy(groupBy as never);
 	}
-	if (Array.isArray(orderBy) && orderBy.length > 0) {
+	if (orderBy.length > 0) {
 		query = query.orderBy(orderBy as never);
 	}
 	if (limit > 0) {

--- a/tests/ActualBudget.spec.ts
+++ b/tests/ActualBudget.spec.ts
@@ -1369,6 +1369,19 @@ describe("ActualBudget", () => {
       await expect(node.execute.call(executeFunctions)).rejects.toThrow(/invalid JSON/);
     });
 
+    it("should throw when rule JSON parses to valid JSON that is not an object", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "createRule";
+        if (name === "resource") return "rule";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "rule") return "[]";
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/"rule" must be a JSON object/);
+      expect(actualApi.createRule).not.toHaveBeenCalled();
+    });
+
     it("should call updateRule with the id merged into the parsed rule JSON", async () => {
       const rule = { stage: null, conditionsOp: "and", conditions: [], actions: [] };
       executeFunctions.getNodeParameter.mockImplementation((name: string) => {
@@ -1831,6 +1844,62 @@ describe("ActualBudget", () => {
       });
 
       await expect(node.execute.call(executeFunctions)).rejects.toThrow(/invalid JSON/);
+    });
+
+    it("should throw on invalid select JSON", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runQuery";
+        if (name === "resource") return "query";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "table") return "transactions";
+        if (name === "filter") return "{}";
+        if (name === "select") return "not json";
+        if (name === "groupBy") return "[]";
+        if (name === "orderBy") return "[]";
+        if (name === "rowLimit") return 0;
+        if (name === "offset") return 0;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/invalid JSON/);
+    });
+
+    it("should throw when groupBy is valid JSON but not an array", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runQuery";
+        if (name === "resource") return "query";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "table") return "transactions";
+        if (name === "filter") return "{}";
+        if (name === "select") return '"*"';
+        if (name === "groupBy") return '{"category": true}';
+        if (name === "orderBy") return "[]";
+        if (name === "rowLimit") return 0;
+        if (name === "offset") return 0;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/"groupBy" must be a JSON array/);
+      expect(fakeQuery.groupBy).not.toHaveBeenCalled();
+    });
+
+    it("should throw when orderBy is valid JSON but not an array", async () => {
+      executeFunctions.getNodeParameter.mockImplementation((name: string) => {
+        if (name === "operation") return "runQuery";
+        if (name === "resource") return "query";
+        if (name === "budgetId") return "test-budget-id";
+        if (name === "table") return "transactions";
+        if (name === "filter") return "{}";
+        if (name === "select") return '"*"';
+        if (name === "groupBy") return "[]";
+        if (name === "orderBy") return '"date"';
+        if (name === "rowLimit") return 0;
+        if (name === "offset") return 0;
+        return undefined;
+      });
+
+      await expect(node.execute.call(executeFunctions)).rejects.toThrow(/"orderBy" must be a JSON array/);
+      expect(fakeQuery.orderBy).not.toHaveBeenCalled();
     });
 
     it("should unwrap the { data, dependencies } envelope and return each row as a separate output item", async () => {

--- a/tests/ActualBudgetIntegration.spec.ts
+++ b/tests/ActualBudgetIntegration.spec.ts
@@ -30,6 +30,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
     return {
       getInputData: () => [{ json: {} }],
       getNodeParameter: (name: string) => params[name],
+      getNode: () => ({ name: "ActualBudget" }),
       getCredentials: async () => ({ url: serverURL, password }),
       continueOnFail: () => false,
       helpers,
@@ -64,6 +65,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
         if (name === "transactions") return JSON.stringify(transactions);
         return undefined;
       },
+      getNode: () => ({ name: "ActualBudget" }),
       getCredentials: async () => ({ url: serverURL, password }),
       continueOnFail: () => false,
       helpers: {
@@ -103,6 +105,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
             return JSON.stringify([{ date: "2024-03-02", amount, notes }]);
           return undefined;
         },
+        getNode: () => ({ name: "ActualBudget" }),
         getCredentials: async () => ({ url: serverURL, password }),
         continueOnFail: () => false,
         helpers: {
@@ -151,6 +154,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
         if (name === "month") return testMonth;
         return undefined;
       },
+      getNode: () => ({ name: "ActualBudget" }),
       getCredentials: async () => ({ url: serverURL, password }),
       continueOnFail: () => false,
       helpers: {
@@ -186,6 +190,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
         if (name === "amount") return 50000;
         return undefined;
       },
+      getNode: () => ({ name: "ActualBudget" }),
       getCredentials: async () => ({ url: serverURL, password }),
       continueOnFail: () => false,
       helpers: {
@@ -225,6 +230,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
         if (name === "endDate") return "2024-03-31";
         return undefined;
       },
+      getNode: () => ({ name: "ActualBudget" }),
       getCredentials: async () => ({ url: serverURL, password }),
       continueOnFail: () => false,
       helpers: {
@@ -469,4 +475,251 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
     const clearedNote = (clearedResult[0][0].json as Record<string, unknown>).note;
     expect(clearedNote === "" || clearedNote === null).toBe(true);
   }, 30000);
+
+  it("should create, read, update, close, reopen, and delete an account via the node", async () => {
+    const accountName = `E2E Test Account ${Date.now()}`;
+    const createResult = await runNode({
+      operation: "createAccount",
+      resource: "account",
+      name: accountName,
+      offbudget: false,
+      initialBalance: 10000,
+    });
+    const newAccountId = (createResult[0][0].json as Record<string, unknown>).id as string;
+    expect(newAccountId).toBeDefined();
+
+    try {
+      const listResult = await runNode({ operation: "getAccounts", resource: "account" });
+      expect(listResult[0].map((item) => (item.json as Record<string, unknown>).id)).toContain(newAccountId);
+
+      const balanceResult = await runNode({
+        operation: "getAccountBalance",
+        resource: "account",
+        accountId: newAccountId,
+        cutoff: "",
+      });
+      expect(typeof (balanceResult[0][0].json as Record<string, unknown>).balance).toBe("number");
+
+      await runNode({
+        operation: "updateAccount",
+        resource: "account",
+        accountId: newAccountId,
+        updateFields: { name: `${accountName} Updated` },
+      });
+
+      // Actual requires a transfer account when closing an account with a non-zero balance
+      // (this one has a $100 initial balance) — real server behavior, discovered by this test.
+      await runNode({
+        operation: "closeAccount",
+        resource: "account",
+        accountId: newAccountId,
+        transferAccountId: accountId,
+        transferCategoryId: "",
+      });
+
+      await runNode({ operation: "reopenAccount", resource: "account", accountId: newAccountId });
+    } finally {
+      await runNode({ operation: "deleteAccount", resource: "account", accountId: newAccountId });
+    }
+
+    const finalListResult = await runNode({ operation: "getAccounts", resource: "account" });
+    expect(finalListResult[0].map((item) => (item.json as Record<string, unknown>).id)).not.toContain(newAccountId);
+  }, 30000);
+
+  it("should create, list, update, and delete a category group via the node", async () => {
+    const groupName = `E2E Test Group ${Date.now()}`;
+    const createResult = await runNode({
+      operation: "createCategoryGroup",
+      resource: "categoryGroup",
+      name: groupName,
+      is_income: false,
+      hidden: false,
+    });
+    const groupId = (createResult[0][0].json as Record<string, unknown>).id as string;
+    expect(groupId).toBeDefined();
+
+    try {
+      const listResult = await runNode({ operation: "getCategoryGroups", resource: "categoryGroup" });
+      expect(listResult[0].map((item) => (item.json as Record<string, unknown>).id)).toContain(groupId);
+
+      await runNode({
+        operation: "updateCategoryGroup",
+        resource: "categoryGroup",
+        categoryGroupId: groupId,
+        updateFields: { name: `${groupName} Updated` },
+      });
+
+      const afterUpdateResult = await runNode({ operation: "getCategoryGroups", resource: "categoryGroup" });
+      const updatedEntry = afterUpdateResult[0].find(
+        (item) => (item.json as Record<string, unknown>).id === groupId,
+      );
+      expect((updatedEntry!.json as Record<string, unknown>).name).toBe(`${groupName} Updated`);
+    } finally {
+      await runNode({
+        operation: "deleteCategoryGroup",
+        resource: "categoryGroup",
+        categoryGroupId: groupId,
+        transferCategoryId: "",
+      });
+    }
+
+    const finalListResult = await runNode({ operation: "getCategoryGroups", resource: "categoryGroup" });
+    expect(finalListResult[0].map((item) => (item.json as Record<string, unknown>).id)).not.toContain(groupId);
+  }, 30000);
+
+  it("should create, list, update, and delete a category via the node", async () => {
+    // Creates its own throwaway category group, since createCategory requires one.
+    const groupCreateResult = await runNode({
+      operation: "createCategoryGroup",
+      resource: "categoryGroup",
+      name: `E2E Test Category Group ${Date.now()}`,
+      is_income: false,
+      hidden: false,
+    });
+    const groupId = (groupCreateResult[0][0].json as Record<string, unknown>).id as string;
+
+    try {
+      const categoryName = `E2E Test Category ${Date.now()}`;
+      const createResult = await runNode({
+        operation: "createCategory",
+        resource: "category",
+        name: categoryName,
+        groupId,
+        is_income: false,
+        hidden: false,
+      });
+      const newCategoryId = (createResult[0][0].json as Record<string, unknown>).id as string;
+      expect(newCategoryId).toBeDefined();
+
+      try {
+        const listResult = await runNode({ operation: "getCategories", resource: "category" });
+        expect(listResult[0].map((item) => (item.json as Record<string, unknown>).id)).toContain(newCategoryId);
+
+        await runNode({
+          operation: "updateCategory",
+          resource: "category",
+          categoryId: newCategoryId,
+          updateFields: { name: `${categoryName} Updated` },
+        });
+
+        const afterUpdateResult = await runNode({ operation: "getCategories", resource: "category" });
+        const updatedEntry = afterUpdateResult[0].find(
+          (item) => (item.json as Record<string, unknown>).id === newCategoryId,
+        );
+        expect((updatedEntry!.json as Record<string, unknown>).name).toBe(`${categoryName} Updated`);
+      } finally {
+        await runNode({
+          operation: "deleteCategory",
+          resource: "category",
+          categoryId: newCategoryId,
+          transferCategoryId: "",
+        });
+      }
+
+      const finalListResult = await runNode({ operation: "getCategories", resource: "category" });
+      expect(finalListResult[0].map((item) => (item.json as Record<string, unknown>).id)).not.toContain(
+        newCategoryId,
+      );
+    } finally {
+      await runNode({
+        operation: "deleteCategoryGroup",
+        resource: "categoryGroup",
+        categoryGroupId: groupId,
+        transferCategoryId: "",
+      });
+    }
+  }, 30000);
+
+  it("should create, list, update, and delete a payee via the node", async () => {
+    const payeeName = `E2E Test New Payee ${Date.now()}`;
+    const createResult = await runNode({
+      operation: "createPayee",
+      resource: "payee",
+      name: payeeName,
+    });
+    const newPayeeId = (createResult[0][0].json as Record<string, unknown>).id as string;
+    expect(newPayeeId).toBeDefined();
+
+    try {
+      const listResult = await runNode({ operation: "getPayees", resource: "payee" });
+      expect(listResult[0].map((item) => (item.json as Record<string, unknown>).id)).toContain(newPayeeId);
+
+      await runNode({
+        operation: "updatePayee",
+        resource: "payee",
+        payeeId: newPayeeId,
+        updateFields: { name: `${payeeName} Updated` },
+      });
+
+      const afterUpdateResult = await runNode({ operation: "getPayees", resource: "payee" });
+      const updatedEntry = afterUpdateResult[0].find(
+        (item) => (item.json as Record<string, unknown>).id === newPayeeId,
+      );
+      expect((updatedEntry!.json as Record<string, unknown>).name).toBe(`${payeeName} Updated`);
+
+      const commonResult = await runNode({ operation: "getCommonPayees", resource: "payee" });
+      expect(Array.isArray(commonResult[0])).toBe(true);
+    } finally {
+      await runNode({ operation: "deletePayee", resource: "payee", payeeId: newPayeeId });
+    }
+
+    const finalListResult = await runNode({ operation: "getPayees", resource: "payee" });
+    expect(finalListResult[0].map((item) => (item.json as Record<string, unknown>).id)).not.toContain(newPayeeId);
+  }, 30000);
+
+  it("should merge a duplicate payee into a target payee via the node", async () => {
+    const targetResult = await runNode({
+      operation: "createPayee",
+      resource: "payee",
+      name: `E2E Merge Target ${Date.now()}`,
+    });
+    const targetPayeeId = (targetResult[0][0].json as Record<string, unknown>).id as string;
+
+    try {
+      const dupeResult = await runNode({
+        operation: "createPayee",
+        resource: "payee",
+        name: `E2E Merge Dupe ${Date.now()}`,
+      });
+      const dupePayeeId = (dupeResult[0][0].json as Record<string, unknown>).id as string;
+
+      await runNode({
+        operation: "mergePayees",
+        resource: "payee",
+        targetPayeeId,
+        mergeIds: [dupePayeeId],
+      });
+
+      const listResult = await runNode({ operation: "getPayees", resource: "payee" });
+      const ids = listResult[0].map((item) => (item.json as Record<string, unknown>).id);
+      expect(ids).toContain(targetPayeeId);
+      expect(ids).not.toContain(dupePayeeId);
+    } finally {
+      await runNode({ operation: "deletePayee", resource: "payee", payeeId: targetPayeeId });
+    }
+  }, 30000);
+
+  it("should surface a real error when the budget does not exist on the server", async () => {
+    // Proves NodeApiError wrapping actually works against a genuine server error, not just
+    // a mocked rejection — every unit test's "error" path uses a mock, never the real API.
+    await expect(
+      runNode({ operation: "getAccounts", resource: "account", budgetId: "nonexistent-budget-id" }),
+    ).rejects.toThrow();
+  }, 15000);
+
+  it("should surface a real AQL compiler error for a nonexistent table", async () => {
+    await expect(
+      runNode({
+        operation: "runQuery",
+        resource: "query",
+        table: "not_a_real_table",
+        filter: "{}",
+        select: '"*"',
+        groupBy: "[]",
+        orderBy: "[]",
+        rowLimit: 0,
+        offset: 0,
+      }),
+    ).rejects.toThrow();
+  }, 15000);
 });

--- a/tests/ActualBudgetIntegration.spec.ts
+++ b/tests/ActualBudgetIntegration.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { ActualBudgetV2 } from "../nodes/ActualBudget/v2/ActualBudgetV2.node";
+import { NodeApiError } from "n8n-workflow";
 import type { IDataObject, IExecuteFunctions } from "n8n-workflow";
 import * as api from "@actual-app/api";
 import { mkdtempSync } from "fs";
@@ -507,6 +508,12 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
         updateFields: { name: `${accountName} Updated` },
       });
 
+      const afterUpdateResult = await runNode({ operation: "getAccounts", resource: "account" });
+      const updatedEntry = afterUpdateResult[0].find(
+        (item) => (item.json as Record<string, unknown>).id === newAccountId,
+      );
+      expect((updatedEntry!.json as Record<string, unknown>).name).toBe(`${accountName} Updated`);
+
       // Actual requires a transfer account when closing an account with a non-zero balance
       // (this one has a $100 initial balance) — real server behavior, discovered by this test.
       await runNode({
@@ -674,6 +681,9 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
       name: `E2E Merge Target ${Date.now()}`,
     });
     const targetPayeeId = (targetResult[0][0].json as Record<string, unknown>).id as string;
+    // Tracked outside the try so a failed merge/assertion still gets cleaned up below, rather
+    // than leaving the duplicate payee behind for the next run.
+    let dupePayeeId: string | undefined;
 
     try {
       const dupeResult = await runNode({
@@ -681,7 +691,7 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
         resource: "payee",
         name: `E2E Merge Dupe ${Date.now()}`,
       });
-      const dupePayeeId = (dupeResult[0][0].json as Record<string, unknown>).id as string;
+      dupePayeeId = (dupeResult[0][0].json as Record<string, unknown>).id as string;
 
       await runNode({
         operation: "mergePayees",
@@ -695,31 +705,44 @@ describe.skipIf(!runIntegration)("ActualBudget Integration", () => {
       expect(ids).toContain(targetPayeeId);
       expect(ids).not.toContain(dupePayeeId);
     } finally {
+      if (dupePayeeId) {
+        const remaining = await runNode({ operation: "getPayees", resource: "payee" });
+        const dupeStillExists = remaining[0].some(
+          (item) => (item.json as Record<string, unknown>).id === dupePayeeId,
+        );
+        if (dupeStillExists) {
+          await runNode({ operation: "deletePayee", resource: "payee", payeeId: dupePayeeId });
+        }
+      }
       await runNode({ operation: "deletePayee", resource: "payee", payeeId: targetPayeeId });
     }
   }, 30000);
 
-  it("should surface a real error when the budget does not exist on the server", async () => {
+  it("should wrap a nonexistent budget as a NodeApiError with the server's detail", async () => {
     // Proves NodeApiError wrapping actually works against a genuine server error, not just
     // a mocked rejection — every unit test's "error" path uses a mock, never the real API.
-    await expect(
-      runNode({ operation: "getAccounts", resource: "account", budgetId: "nonexistent-budget-id" }),
-    ).rejects.toThrow();
+    const promise = runNode({
+      operation: "getAccounts",
+      resource: "account",
+      budgetId: "nonexistent-budget-id",
+    });
+    await expect(promise).rejects.toBeInstanceOf(NodeApiError);
+    await expect(promise).rejects.toThrow('Budget "nonexistent-budget-id" not found');
   }, 15000);
 
-  it("should surface a real AQL compiler error for a nonexistent table", async () => {
-    await expect(
-      runNode({
-        operation: "runQuery",
-        resource: "query",
-        table: "not_a_real_table",
-        filter: "{}",
-        select: '"*"',
-        groupBy: "[]",
-        orderBy: "[]",
-        rowLimit: 0,
-        offset: 0,
-      }),
-    ).rejects.toThrow();
+  it("should wrap a nonexistent AQL table as a NodeApiError with the server's detail", async () => {
+    const promise = runNode({
+      operation: "runQuery",
+      resource: "query",
+      table: "not_a_real_table",
+      filter: "{}",
+      select: '"*"',
+      groupBy: "[]",
+      orderBy: "[]",
+      rowLimit: 0,
+      offset: 0,
+    });
+    await expect(promise).rejects.toBeInstanceOf(NodeApiError);
+    await expect(promise).rejects.toThrow('Table "not_a_real_table" does not exist');
   }, 15000);
 });


### PR DESCRIPTION
## Summary
Follow-up to #242, closing the specific gaps identified there:

**Production behavior fix:**
- `nodes/ActualBudget/v2/actions/query.ts`: `groupBy`/`orderBy` now validate they're JSON arrays instead of silently no-op'ing on malformed input (e.g. a user pasting `{}` instead of `[]` previously just got an unfiltered/ungrouped query with no warning).

**Edge-case unit tests:**
- Rule: "must be a JSON object" validation (implemented, previously untested).
- Query: invalid JSON in `select`, and the new groupBy/orderBy array validation.

**Live integration coverage** (against the Dockerized Actual server):
- Full CRUD lifecycles for Account, Category, CategoryGroup, and Payee (the four resources with zero prior live coverage) plus a Payee merge test.
- Two tests that trigger genuine server-side errors (nonexistent budget ID, nonexistent AQL table) to prove `NodeApiError`/`NodeOperationError` wrapping works against a real error, not just a mocked one.

**Bugs this surfaced along the way:**
- Every inline execute-context mock in `ActualBudgetIntegration.spec.ts` was missing `getNode()`, so any genuine API error crashed with a masking `context.getNode is not a function` TypeError instead of the real error — silently, since a bare `.rejects.toThrow()` doesn't care which error it catches. Fixed everywhere in the file.
- That fix then surfaced real behavior: Actual's API refuses to close an account with a non-zero balance unless `transferAccountId` is given. The account lifecycle test now exercises that transfer path for real.

Operation-level live integration coverage goes from ~51% (27/53, after #242) to ~91% (48/53). Remaining gaps: `budget.sync`/`budget.runBankSync` (no real bank-link credential available in this harness) and `transaction.addTransactions`/`updateTransaction`/`deleteTransaction`.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run test:pipeline` (full Docker-based pipeline against a real Actual server) — 7/7 test files, 149/149 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for JSON query parameters.
  * Invalid values for rule creation, field selection, grouping, and sorting are now rejected with clear errors before execution.
  * Requests targeting nonexistent budgets or invalid tables now return appropriate server errors.

* **Tests**
  * Added regression and end-to-end coverage for budget, account, category, payee, and payee-merge operations.
  * Added coverage confirming invalid inputs are rejected before requests are executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->