### PR TITLE
Batch releases to the nightly cron instead of every push [no-release]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
   schedule:
-    # Runs at 00:00 UTC every day
-    - cron: '0 0 * * *'
+    # Runs at 03:17 UTC every day. Off the hour/half-hour on purpose - GitHub
+    # Actions queues everyone's "0 0 * * *" cron jobs at once, which delays
+    # them; an odd offset avoids that pile-up.
+    - cron: '17 3 * * *'
   workflow_dispatch: # Allows manual triggering
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,15 @@ jobs:
       # instead. Opening/merging it as the app (not the default GITHUB_TOKEN)
       # means ci.yml actually triggers on it, so the merge is a normal,
       # check-satisfying merge rather than something needing a bypass.
+      #
+      # Only ever opened from the nightly cron (or a manual dispatch), never
+      # from an ordinary push: that batches everything merged to main since
+      # the last run into a single release instead of cutting one per push.
+      # A plain push still runs this job, but only to handle the "Tag and
+      # Publish" step below (finishing a release already in flight).
       - name: Open Release PR
         if: >-
+          github.event_name != 'push' &&
           steps.check_version.outputs.IS_RELEASE_COMMIT != 'true' &&
           steps.check_version.outputs.SKIP_RELEASE != 'true'
         env:


### PR DESCRIPTION
## Summary
- The release pipeline currently opens a new release PR on *every* push to `main` (only suppressed via a manual `[no-release]` commit-message suffix). This makes it match `n8n-nodes-pocketbase`'s `nightly.yml`, which already splits push vs. cron responsibilities: pushes only finish an in-flight release (tag + publish), and only the nightly cron / manual dispatch decides whether to open a new one.
- `Open Release PR` now requires `github.event_name != 'push'` in addition to the existing conditions.
- Net effect: multiple merges to `main` in a day accumulate silently and get bundled into a single release at the next nightly run (00:00 UTC), instead of one release per merge. Still fully automatic — no labels or manual steps needed on a normal day.

## Test plan
- [x] Validated YAML syntax locally
- [ ] Merge and confirm a same-day push does *not* open a release PR
- [ ] Confirm the next nightly cron run opens exactly one release PR covering all pending changes, and it still auto-merges and publishes as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release pull requests are no longer created by ordinary pushes.
  * Scheduled and manually triggered runs can now create release pull requests, while push-triggered runs continue tagging and publishing existing releases.

* **Chores**
  * Daily releases are now scheduled for 03:17 UTC to support release batching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->