### PR TITLE
Drop the [no-release] convention, now dead weight

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,30 +57,6 @@ jobs:
           npm run version:update
           npm install
 
-      - name: Detect change type
-        if: steps.check_updates.outputs.updates_found == 'true'
-        id: change_type
-        run: |
-          RELEASE=false
-
-          # Any @actual-app/api change warrants a release
-          if git diff package.json | grep -q '"@actual-app/api"'; then
-            RELEASE=true
-          fi
-
-          # Major or minor n8n-workflow bump warrants a release
-          if git diff package.json | grep -q '"n8nWorkflowVersion"'; then
-            OLD_N8N=$(git show HEAD:package.json | jq -r '.n8nWorkflowVersion' | sed 's/^[^0-9]*//')
-            NEW_N8N=$(jq -r '.n8nWorkflowVersion' package.json | sed 's/^[^0-9]*//')
-            OLD_MM="${OLD_N8N%.*}"
-            NEW_MM="${NEW_N8N%.*}"
-            if [ "$OLD_MM" != "$NEW_MM" ]; then
-              RELEASE=true
-            fi
-          fi
-
-          echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
-
       - name: Run pipeline
         if: steps.check_updates.outputs.updates_found == 'true'
         run: npm run test:pipeline
@@ -92,14 +68,12 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
           commit-message: "chore: nightly compatibility updates"
-          title: >-
-            Nightly Compatibility Updates${{ steps.change_type.outputs.release == 'false' && ' [no-release]' || '' }}
+          title: "Nightly Compatibility Updates"
           body: "Automated nightly updates for compatibility versions."
           branch: nightly-updates
           base: main
           delete-branch: true
           sign-commits: true
-          update-pull-request-title: true
 
       - name: Enable Auto-Merge
         if: steps.cpr.outputs.pull-request-number != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ permissions:
 
 jobs:
   sync-publish:
-    if: >-
-      github.event_name != 'push' ||
-      !contains(github.event.head_commit.message, '[no-release]')
     runs-on: ubuntu-latest
 
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -11,18 +11,12 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
-      "automergeType": "pr",
-      "commitMessageSuffix": "[no-release]"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "commitMessageSuffix": "[no-release]"
+      "automergeType": "pr"
     },
     {
       "matchManagers": ["github-actions"],
       "automerge": true,
-      "automergeType": "pr",
-      "commitMessageSuffix": "[no-release]"
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Follow-up to #247. Now that `Open Release PR` only fires from the nightly cron / manual dispatch, a push to `main` can never open a release regardless of its commit message — so the `[no-release]` message-based job skip in `release.yml` no longer serves its original purpose. It still saved a CI run on tagged pushes, but at the cost of a convention nobody needs to think about anymore.

Also found the same pattern already inert in `nightly.yml`: its "Detect change type" step decided whether to suffix its own PR title with `[no-release]`, but that suffix's only effect was on the immediate push-triggered release (now impossible) — the nightly cron's "commits since last tag" check was never filtered by commit message, so a `RELEASE=false` compatibility update was already going to get bundled into the next scheduled release either way.

- `release.yml`: drop the job-level `[no-release]` message check
- `nightly.yml`: drop "Detect change type" and the conditional PR title it fed; title is now static
- `renovate.json`: drop `commitMessageSuffix` from the automerge rules, and the now-empty major-update rule that existed only to add it

## Test plan
- [x] Validated YAML/JSON syntax locally
- [ ] Confirm `ci.yml` passes on this PR
- [ ] Confirm the next nightly cron / Renovate automerge behaves the same as before (still batches, still automerges) with no `[no-release]` anywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified automated release handling by removing special-case rules that previously prevented selected changes from being released.
  * Automated release pull requests now use a consistent title and behavior.
  * Publishing workflows run without excluding changes based on commit-message markers.
  * Dependency update automation continues to support automatic handling for minor, patch, pinned, digest, and workflow updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->